### PR TITLE
Use same session when fetch aws account id

### DIFF
--- a/lambroll.go
+++ b/lambroll.go
@@ -75,7 +75,7 @@ func (app *App) AWSAccountID() string {
 	if app.accountID != "" {
 		return app.accountID
 	}
-	svc := sts.New(session.New())
+	svc := sts.New(app.sess)
 	r, err := svc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
 		log.Println("[warn] failed to get caller identity", err)


### PR DESCRIPTION
I fixed a bit due to the following reasons. Please review this when you're available 🙏 

### Reason
* `session.New()` is deprecated. 
* Cannot load region setting from argument in this service. (important)
* Sharing same session among services is officially recommended.

ref: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#New

