### PR TITLE
Fix: fail add alias when create new function

### DIFF
--- a/create.go
+++ b/create.go
@@ -68,6 +68,7 @@ func (app *App) create(opt DeployOption, fn *Function) error {
 			return errors.Wrap(err, "failed to create function")
 		}
 		if res.Version != nil {
+			version = *res.Version
 			log.Printf("[info] deployed function version %s", *res.Version)
 		} else {
 			log.Println("[info] deployed")


### PR DESCRIPTION
Alias registration fails, when creating a new Lambda function.

error example:
```
lambroll deploy --function="function.json" --exclude-file=".lambdaignore"
2019/12/02 15:27:38 [info] lambroll v0.3.1
2019/12/02 15:27:38 [info] starting deploy function some-func
2019/12/02 15:27:39 [info] creating zip archive from .
2019/12/02 15:27:40 [info] zip archive wrote 7524305 bytes
2019/12/02 15:27:40 [info] creating function 
2019/12/02 15:27:42 [info] deployed function version 1
2019/12/02 15:27:42 [info] creating alias set current to version (created) 
2019/12/02 15:27:42 [error] failed to create alias: ValidationException: 1 validation error detected: Value '(created)' at 'functionVersion' failed to satisfy constraint: Member must satisfy regular expression pattern: (\$LATEST|[0-9]+)
	status code: 400, request id: xxxx-xxxx-xxxx-xxxx-xxxx
```