### PR TITLE
Fixed panic when invoking function with --async option

### DIFF
--- a/invoke.go
+++ b/invoke.go
@@ -66,7 +66,10 @@ PAYLOAD:
 		stdout.Write([]byte("\n"))
 		stdout.Flush()
 
-		log.Printf("[info] StatusCode:%d ExecutionVersion:%s", *res.StatusCode, *res.ExecutedVersion)
+		log.Printf("[info] StatusCode:%d", *res.StatusCode)
+		if res.ExecutedVersion != nil {
+			log.Printf("[info] ExecutionVersion:%s", *res.ExecutedVersion)
+		}
 		if res.LogResult != nil {
 			b, _ := base64.StdEncoding.DecodeString(*res.LogResult)
 			stderr.Write(b)


### PR DESCRIPTION
fixes #8 

Added a check to ensure `res.ExecutedVersion` is not nil.

# execution log

## before

```
# with async
❯ echo '{"Name":"lambroll"}' | lambroll invoke --region ap-northeast-1 --async --log-tail
2020/01/14 05:57:52 [info] lambroll v0.3.2

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x15f02a8]

goroutine 1 [running]:
github.com/fujiwara/lambroll.(*App).Invoke(0xc00000d760, 0xc000061ca0, 0xc000028f46, 0xc000028f47, 0x0, 0xc000061db0)
	/home/runner/work/lambroll/lambroll/invoke.go:69 +0x628
main._main(0xc00007e058)
	/home/runner/work/lambroll/lambroll/cmd/lambroll/main.go:103 +0x26de
main.main()
	/home/runner/work/lambroll/lambroll/cmd/lambroll/main.go:17 +0x22

# without async
❯ echo '{"Name":"lambroll"}' | lambroll invoke --region ap-northeast-1 --log-tail
2020/01/14 05:57:56 [info] lambroll v0.3.2
"undefined is awesome"
2020/01/14 05:57:56 [info] StatusCode:200 ExecutionVersion:$LATEST
START RequestId: 8b659ef5-ebdb-42eb-8e7a-b76bbba7f736 Version: $LATEST
END RequestId: 8b659ef5-ebdb-42eb-8e7a-b76bbba7f736
REPORT RequestId: 8b659ef5-ebdb-42eb-8e7a-b76bbba7f736	Duration: 0.89 ms	Billed Duration: 100 ms	Memory Size: 128 MB	Max Memory Used: 76 MB
2020/01/14 05:57:56 [info] completed
```

## after

```

# with async
❯ echo '{"Name":"lambroll"}' | lambroll invoke --region ap-northeast-1 --async --log-tail
2020/01/14 05:49:14 [info] lambroll current

2020/01/14 05:49:14 [info] StatusCode:202
2020/01/14 05:49:14 [info] completed

# without async
❯ echo '{"Name":"lambroll"}' | lambroll invoke --region ap-northeast-1  --log-tail
2020/01/14 05:53:56 [info] lambroll current
"undefined is awesome"
2020/01/14 05:53:57 [info] StatusCode:200
2020/01/14 05:53:57 [info] ExecutionVersion:$LATEST
START RequestId: ef069361-8715-4e46-89a7-1391b7c505ba Version: $LATEST
END RequestId: ef069361-8715-4e46-89a7-1391b7c505ba
REPORT RequestId: ef069361-8715-4e46-89a7-1391b7c505ba	Duration: 0.92 ms	Billed Duration: 100 ms	Memory Size: 128 MB	Max Memory Used: 76 MB
2020/01/14 05:53:57 [info] completed
```