### PR TITLE
add --profile option

### DIFF
--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -22,6 +22,7 @@ func _main() int {
 	region := kingpin.Flag("region", "AWS region").Default(os.Getenv("AWS_REGION")).String()
 	logLevel := kingpin.Flag("log-level", "log level (trace, debug, info, warn, error)").Default("info").Enum("trace", "debug", "info", "warn", "error")
 	function := kingpin.Flag("function", "Function file path").Default(lambroll.FunctionFilename).String()
+	profile := kingpin.Flag("profile", "AWS credential profile name").Default("default").String()
 
 	init := kingpin.Command("init", "init function.json")
 	initOption := lambroll.InitOption{
@@ -77,7 +78,7 @@ func _main() int {
 	}
 	log.SetOutput(filter)
 
-	app, err := lambroll.New(*region)
+	app, err := lambroll.New(*region, *profile)
 	if err != nil {
 		log.Println("[error]", err)
 		return 1

--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -22,7 +22,7 @@ func _main() int {
 	region := kingpin.Flag("region", "AWS region").Default(os.Getenv("AWS_REGION")).String()
 	logLevel := kingpin.Flag("log-level", "log level (trace, debug, info, warn, error)").Default("info").Enum("trace", "debug", "info", "warn", "error")
 	function := kingpin.Flag("function", "Function file path").Default(lambroll.FunctionFilename).String()
-	profile := kingpin.Flag("profile", "AWS credential profile name").Default("default").String()
+	profile := kingpin.Flag("profile", "AWS credential profile name").Default(os.Getenv("AWS_PROFILE")).String()
 
 	init := kingpin.Command("init", "init function.json")
 	initOption := lambroll.InitOption{

--- a/lambroll.go
+++ b/lambroll.go
@@ -3,7 +3,6 @@ package lambroll
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -59,12 +58,14 @@ type App struct {
 
 // New creates an application
 func New(region string, profile string) (*App, error) {
-	os.Setenv("AWS_PROFILE", profile)
 	conf := &aws.Config{}
 	if region != "" {
 		conf.Region = aws.String(region)
 	}
-	sess := session.Must(session.NewSession(conf))
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		Profile: profile,
+		Config: *conf,
+	}))
 
 	return &App{
 		sess:   sess,

--- a/lambroll.go
+++ b/lambroll.go
@@ -3,6 +3,7 @@ package lambroll
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -57,7 +58,8 @@ type App struct {
 }
 
 // New creates an application
-func New(region string) (*App, error) {
+func New(region string, profile string) (*App, error) {
+	os.Setenv("AWS_PROFILE", profile)
 	conf := &aws.Config{}
 	if region != "" {
 		conf.Region = aws.String(region)


### PR DESCRIPTION
## Summary
I added the `--profile` option.

ex) 
```zsh
% go run cmd/lambroll/main.go init --function-name test-func --region "ap-northeast-1" --profile "test"
% go run cmd/lambroll/main.go deploy --region "ap-northeast-1" --profile "test"
# If not specified, it will be "default"
% go run cmd/lambroll/main.go deploy --region "ap-northeast-1" 
```

## Reason
Currently, I think Lambroll can only load default credential.
When registering multiple credentials in my local environment like the AWS CLI, I want to switch credentials and use them.


Please confirm. 🙏 
