### PR TITLE
Add logs sub command.

### DIFF
--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -69,6 +69,15 @@ func _main() int {
 		ExcludeFile: archive.Flag("exclude-file", "exclude file").Default(lambroll.IgnoreFilename).String(),
 	}
 
+	logs := kingpin.Command("logs", "tail logs using `aws logs tail` (aws-cli v2 required)")
+	logsOption := lambroll.LogsOption{
+		FunctionFilePath: function,
+		Since:            logs.Flag("since", "From what time to begin displaying logs").Default("10m").String(),
+		Follow:           logs.Flag("follow", "follow new logs").Default("false").Bool(),
+		Format:           logs.Flag("format", "The format to display the logs").Default("detailed").String(),
+		FilterPattern:    logs.Flag("filter-pattern", "The filter  pattern to use").Default("").String(),
+	}
+
 	command := kingpin.Parse()
 
 	filter := &logutils.LevelFilter{
@@ -104,6 +113,8 @@ func _main() int {
 		err = app.Invoke(invokeOption)
 	case "archive":
 		err = app.Archive(archiveOption)
+	case "logs":
+		err = app.Logs(logsOption)
 	}
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,8 @@ require (
 	github.com/go-test/deep v1.0.4
 	github.com/hashicorp/logutils v1.0.0
 	github.com/kayac/go-config v0.1.0
-	github.com/mattn/go-isatty v0.0.8 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/pkg/errors v0.8.1
 	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
+	golang.org/x/sys v0.0.0-20191115151921-52ab43148777 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/kayac/go-config v0.1.0 h1:Yu087bRps9BcmWK9HcuIBGI/YLpmLXYASzPZVZKc8UY
 github.com/kayac/go-config v0.1.0/go.mod h1:m8920IaLog2vC6iFDMSROoD3n98ThCBW+XzroliX3Bc=
 github.com/mattn/go-isatty v0.0.7 h1:UvyT9uN+3r7yLEYSlJsbQGdsaB/a0DlgWP3pql6iwOc=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
-github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -40,6 +40,9 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191115151921-52ab43148777 h1:wejkGHRTr38uaKRqECZlsCsJ1/TGxIyFbH32x5zUdu4=
+golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/lambroll.go
+++ b/lambroll.go
@@ -54,6 +54,7 @@ type App struct {
 	sess      *session.Session
 	lambda    *lambda.Lambda
 	accountID string
+	profile   string
 }
 
 // New creates an application
@@ -64,12 +65,13 @@ func New(region string, profile string) (*App, error) {
 	}
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		Profile: profile,
-		Config: *conf,
+		Config:  *conf,
 	}))
 
 	return &App{
-		sess:   sess,
-		lambda: lambda.New(sess),
+		sess:    sess,
+		lambda:  lambda.New(sess),
+		profile: profile,
 	}, nil
 }
 

--- a/logs.go
+++ b/logs.go
@@ -1,0 +1,57 @@
+package lambroll
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+type LogsOption struct {
+	FunctionFilePath *string
+	Since            *string
+	Follow           *bool
+	Format           *string
+	FilterPattern    *string
+}
+
+func (app *App) Logs(opt LogsOption) error {
+	fn, err := app.loadFunction(*opt.FunctionFilePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to load function")
+	}
+
+	logGroup := "/aws/lambda/" + *fn.FunctionName
+	command := []string{
+		"aws",
+		"--profile", app.profile,
+		"--region", *app.sess.Config.Region,
+		"logs",
+		"tail",
+		logGroup,
+	}
+	if opt.Since != nil {
+		command = append(command, "--since", *opt.Since)
+	}
+	if opt.Follow != nil && *opt.Follow {
+		command = append(command, "--follow")
+	}
+	if opt.Format != nil {
+		command = append(command, "--format", *opt.Format)
+	}
+	if opt.FilterPattern != nil && *opt.FilterPattern != "" {
+		command = append(command, "--filter-pattern", *opt.FilterPattern)
+	}
+	bin, err := exec.LookPath(command[0])
+	if err != nil {
+		return err
+	}
+	log.Println("[debug] invoking command", strings.Join(command, " "))
+	if err := syscall.Exec(bin, command, os.Environ()); err != nil {
+		return errors.Wrap(err, "failed to invoke aws logs tail")
+	}
+	return nil
+}


### PR DESCRIPTION
Invokes `aws logs tail`.

refs #10 

```
usage: lambroll logs [<flags>]

tail logs using `aws logs tail` (aws-cli v2 required)

Flags:
  --since="10m"               From what time to begin displaying logs
  --follow                    follow new logs
  --format="detailed"         The format to display the logs
  --filter-pattern=""         The filter pattern to use
```

Options are the same as `aws logs tail`.