### PR TITLE
fix handling for empty global options.

### DIFF
--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -83,6 +83,10 @@ func _main() int {
 	}
 
 	command := kingpin.Parse()
+	if command == "version" {
+		fmt.Println("lambroll", Version)
+		return 0
+	}
 
 	filter := &logutils.LevelFilter{
 		Levels:   []logutils.LogLevel{"trace", "debug", "info", "warn", "error"},
@@ -95,10 +99,6 @@ func _main() int {
 	if err != nil {
 		log.Println("[error]", err)
 		return 1
-	}
-	if command == "version" {
-		fmt.Println("lambroll", Version)
-		return 0
 	}
 
 	log.Println("[info] lambroll", Version)

--- a/lambroll.go
+++ b/lambroll.go
@@ -64,19 +64,19 @@ type App struct {
 // New creates an application
 func New(opt *Option) (*App, error) {
 	awsCfg := &aws.Config{}
-	if opt.Region != nil {
+	if opt.Region != nil && *opt.Region != "" {
 		awsCfg.Region = aws.String(*opt.Region)
 	}
 	sessOpt := session.Options{Config: *awsCfg}
 	var profile string
-	if opt.Profile != nil {
+	if opt.Profile != nil && *opt.Profile != "" {
 		sessOpt.Profile = *opt.Profile
 		profile = *opt.Profile
 	}
 	sess := session.Must(session.NewSessionWithOptions(sessOpt))
 
 	loader := config.New()
-	if opt.TFState != nil {
+	if opt.TFState != nil && *opt.TFState != "" {
 		funcs, err := tfstate.Load(*opt.TFState)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
v0.5.1 failed to run without --tfstate option.

```console
$ lambroll version
2020/04/07 12:08:15 [error] failed to read tfstate: : open : no such file or directory
```
