### PR TITLE
add feature: custom endpoints option for AWS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Flags:
   --log-level=info            log level (trace, debug, info, warn, error)
   --function="function.json"  Function file path
   --tfstate=""                path to terraform.tfstate
+  --endpoint=""               AWS API Lambda Endpoint
 
 Commands:
   help [<command>...]

--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -23,9 +23,10 @@ func _main() int {
 	function := kingpin.Flag("function", "Function file path").Default(lambroll.FunctionFilename).String()
 
 	opt := lambroll.Option{
-		Profile: kingpin.Flag("profile", "AWS credential profile name").Default(os.Getenv("AWS_PROFILE")).String(),
-		Region:  kingpin.Flag("region", "AWS region").Default(os.Getenv("AWS_REGION")).String(),
-		TFState: kingpin.Flag("tfstate", "path to terraform.tfstate").Default("").String(),
+		Profile:  kingpin.Flag("profile", "AWS credential profile name").Default(os.Getenv("AWS_PROFILE")).String(),
+		Region:   kingpin.Flag("region", "AWS region").Default(os.Getenv("AWS_REGION")).String(),
+		TFState:  kingpin.Flag("tfstate", "path to terraform.tfstate").Default("").String(),
+		Endpoint: kingpin.Flag("endpoint", "AWS API Lambda Endpoint").Default("").String(),
 	}
 
 	init := kingpin.Command("init", "init function.json")

--- a/option.go
+++ b/option.go
@@ -1,7 +1,8 @@
 package lambroll
 
 type Option struct {
-	Region  *string
-	Profile *string
-	TFState *string
+	Region   *string
+	Profile  *string
+	TFState  *string
+	Endpoint *string
 }


### PR DESCRIPTION
In cases, want to set custom endpoints of AWS API. For example it uses a mock of AWS API on local development.

So this pull request add a feature to lambroll command option that `--endpoint`.

Usage:
```console
$ lambroll deploy --endpoint http://localhost:4566
```