### PR TITLE
Skip archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,17 +144,18 @@ usage: lambroll deploy [<flags>]
 deploy or create function
 
 Flags:
-  --help                      Show context-sensitive help (also try --help-long
-                              and --help-man).
-  --region="ap-northeast-1"   AWS region
-  --log-level=info            log level (trace, debug, info, warn, error)
   --function="function.json"  Function file path
+  --profile="$AWS_PROFILE"    AWS credential profile name
+  --region="$AWS_REGION"      AWS region
+  --tfstate=""                path to terraform.tfstate
+  --endpoint=""               AWS API Lambda Endpoint
   --src="."                   function zip archive or src dir
-  --exclude-file=".lambdaignore"  
+  --exclude-file=".lambdaignore"
                               exclude file
   --dry-run                   dry run
   --publish                   publish function
   --alias="current"           alias name for publish
+  --skip-archive              skip to create zip archive. requires Code.S3Bucket and Code.S3Key in function definition
 ```
 
 `deploy` works as below.

--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -46,6 +46,7 @@ func _main() int {
 		DryRun:           deploy.Flag("dry-run", "dry run").Bool(),
 		Publish:          deploy.Flag("publish", "publish function").Default("true").Bool(),
 		AliasName:        deploy.Flag("alias", "alias name for publish").Default(lambroll.CurrentAliasName).String(),
+		SkipArchive:      deploy.Flag("skip-archive", "skip to create zip archive. requires Code.S3Bucket and Code.S3Key in function definition").Default("false").Bool(),
 	}
 
 	rollback := kingpin.Command("rollback", "rollback function")

--- a/create.go
+++ b/create.go
@@ -19,6 +19,13 @@ func (app *App) prepareFunctionCodeForDeploy(opt DeployOption, fn *Function) err
 		info    os.FileInfo
 	)
 
+	if opt.SkipArchive != nil && *opt.SkipArchive {
+		if fn.Code == nil || fn.Code.S3Bucket == nil || fn.Code.S3Key == nil {
+			return errors.New("--skip-archive requires Code.S3Bucket and Code.S3key elements in function definition")
+		}
+		return nil
+	}
+
 	src := *opt.Src
 	if fi, err := os.Stat(src); err != nil {
 		return errors.Wrapf(err, "src %s is not found", src)

--- a/deploy.go
+++ b/deploy.go
@@ -22,6 +22,7 @@ type DeployOption struct {
 	Publish          *bool
 	AliasName        *string
 	DryRun           *bool
+	SkipArchive      *bool
 }
 
 func (opt DeployOption) label() string {


### PR DESCRIPTION
Add --skip-archive option to deploy sub command.

Enables to put function code to S3 in advance.
