### PR TITLE
Add --envfile option to read environment variables from files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Flags:
   --function="function.json"  Function file path
   --tfstate=""                URL to terraform.tfstate
   --endpoint=""               AWS API Lambda Endpoint
+  --envfile=ENVFILE ...       environment files
 
 Commands:
   help [<command>...]
@@ -359,6 +360,17 @@ Environment variable `FOO` is expanded. When `FOO` is not defined, lambroll will
         }
     }
 }
+```
+
+#### Enviroment variables from envfile
+
+`lambroll --envfile .env1 .env2` reads files named .env1 and .env2 as environment files and export variables in these files.
+
+These files are parsed by [hashicorp/go-envparse](https://github.com/hashicorp/go-envparse).
+
+```env
+FOO=foo
+export BAR="bar"
 ```
 
 #### Lookup resource attributes in tfstate ([Terraform state](https://www.terraform.io/docs/state/index.html))

--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -27,6 +27,7 @@ func _main() int {
 		Region:   kingpin.Flag("region", "AWS region").Default(os.Getenv("AWS_REGION")).String(),
 		TFState:  kingpin.Flag("tfstate", "URL to terraform.tfstate").Default("").String(),
 		Endpoint: kingpin.Flag("endpoint", "AWS API Lambda Endpoint").Default("").String(),
+		Envfile:  kingpin.Flag("envfile", "environment files").Strings(),
 	}
 
 	init := kingpin.Command("init", "init function.json")

--- a/function_test.go
+++ b/function_test.go
@@ -7,10 +7,12 @@ import (
 
 func TestLoadFunction(t *testing.T) {
 	os.Setenv("FUNCTION_NAME", "test")
-	os.Setenv("JSON", `{"foo":"bar"}`)
-	os.Setenv("WORLD", "a")
+	envfiles := []string{"test/env"}
 	path := "test/terraform.tfstate"
-	app, err := New(&Option{TFState: &path})
+	app, err := New(&Option{
+		TFState: &path,
+		Envfile: &envfiles,
+	})
 	if err != nil {
 		t.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.11
 	github.com/fujiwara/tfstate-lookup v0.1.3
 	github.com/go-test/deep v1.0.7
+	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e
 	github.com/hashicorp/logutils v1.0.0
 	github.com/kayac/go-config v0.5.1
 	github.com/kylelemons/godebug v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.11 h1:W1gUQxt6jmiUsk2jkTVAlYsd3Sg8bNL2VDcWjrXmD+0=
 github.com/aws/aws-sdk-go v1.37.11/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -31,6 +30,8 @@ github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e h1:v1d9+AJMP6i4p8BSKNU0InuvmIAdZjQLNN19V86AG4Q=
+github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e/go.mod h1:/NlxCzN2D4C4L2uDE6ux/h6jM+n98VFQM14nnCIfHJU=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=

--- a/option.go
+++ b/option.go
@@ -1,8 +1,10 @@
 package lambroll
 
+// Option represents common option.
 type Option struct {
 	Region   *string
 	Profile  *string
 	TFState  *string
 	Endpoint *string
+	Envfile  *[]string
 }

--- a/test/env
+++ b/test/env
@@ -1,0 +1,2 @@
+export JSON='{"foo":"bar"}'
+WORLD="a"


### PR DESCRIPTION
`lambroll --envfile .env1 .env2` reads files named .env1 and .env2 as environment files and export variables in these files.

These files are parsed by [hashicorp/go-envparse](https://github.com/hashicorp/go-envparse).

```env
FOO=foo
export BAR="bar"
```