### PR TITLE
Added `keep-versions` option into deploy-command

### DIFF
--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -49,6 +49,7 @@ func _main() int {
 		AliasName:        deploy.Flag("alias", "alias name for publish").Default(lambroll.CurrentAliasName).String(),
 		AliasToLatest:    deploy.Flag("alias-to-latest", "set alias to unpublished $LATEST version").Default("false").Bool(),
 		SkipArchive:      deploy.Flag("skip-archive", "skip to create zip archive. requires Code.S3Bucket and Code.S3Key in function definition").Default("false").Bool(),
+		KeepVersions:     deploy.Flag("keep-versions", "Number of latest versions to keep. Older versions will be deleted. (Optional value: default 0).").Default("0").Int(),
 	}
 
 	rollback := kingpin.Command("rollback", "rollback function")


### PR DESCRIPTION
I would like to delete lambda older versions due to [storage limit](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html) 75GB is there.
So a `keep-versions` option is created on deploy-command, which it is kicked by a positive-number. 
(Default value is 0, therefore it behaves as a optional)

Would you mind interesting this solution.
Thanks.

**Below is running outputs.**

```sh
$ make cmd/lambroll/lambroll && ./cmd/lambroll/lambroll deploy --keep-versions=10
make: 'cmd/lambroll/lambroll' is up to date.
2021/09/08 22:00:47 [info] lambroll v0.11.7
2021/09/08 22:00:47 [info] starting deploy function myfunction
2021/09/08 22:00:48 [info] creating zip archive from .
2021/09/08 22:00:48 [info] zip archive wrote 6731149 bytes
2021/09/08 22:00:48 [info] updating function configuration
2021/09/08 22:00:49 [info] updating function code
2021/09/08 22:00:50 [info] deployed version 20
2021/09/08 22:00:50 [info] updating alias set current to version 20
2021/09/08 22:00:50 [info] alias updated
2021/09/08 22:00:52 [info] deleting function version: 1
2021/09/08 22:00:52 [info] deleting function version: 2
2021/09/08 22:00:52 [info] deleting function version: 3
2021/09/08 22:00:52 [info] deleting function version: 4
2021/09/08 22:00:53 [info] deleting function version: 5
2021/09/08 22:00:53 [info] deleting function version: 6
2021/09/08 22:00:53 [info] deleting function version: 7
2021/09/08 22:00:53 [info] deleting function version: 8
2021/09/08 22:00:53 [info] deleting function version: 9
2021/09/08 22:00:53 [info] except 10 latest versions are deleted
2021/09/08 22:00:53 [info] completed
```