### PR TITLE
Add support for arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ function.json is a definition for Lambda function. JSON structure is based from 
 
 ```json
 {
+  "Architectures": [
+    "arm64"
+  ],
   "Description": "hello function for {{ must_env `ENV` }}",
   "Environment": {
     "Variables": {

--- a/function_test.go
+++ b/function_test.go
@@ -35,5 +35,9 @@ func TestLoadFunction(t *testing.T) {
 	if *fn.VpcConfig.SecurityGroupIds[0] != "sg-01a9b01eab0a3c154" {
 		t.Errorf("unexpected SecurityGroupIds %v", fn.VpcConfig.SecurityGroupIds)
 	}
+	arch := fn.Architectures
+	if len(arch) != 2 || *arch[0] != "x86_64" || *arch[1] != "arm64" {
+		t.Errorf("unexpected Architectures %v", fn.Architectures)
+	}
 	t.Log(fn.String())
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Songmu/prompter v0.5.0
 	github.com/alecthomas/kingpin v2.2.6+incompatible
-	github.com/aws/aws-sdk-go v1.40.28
+	github.com/aws/aws-sdk-go v1.40.52
 	github.com/fujiwara/tfstate-lookup v0.4.0
 	github.com/go-test/deep v1.0.7
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,9 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/aws/aws-sdk-go v1.40.28 h1:IWzkX36BHx9R4jYd5y8NAudk8sxUeJHHohZgPI9kq/A=
 github.com/aws/aws-sdk-go v1.40.28/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.40.52 h1:IIQa/hmp61SlRrJF4zxQDFaC2jLUEJDRCxcUEgGyMtg=
+github.com/aws/aws-sdk-go v1.40.52/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/lambroll.go
+++ b/lambroll.go
@@ -153,6 +153,7 @@ func (app *App) loadFunction(path string) (*Function, error) {
 
 func newFuctionFrom(c *lambda.FunctionConfiguration, tags Tags) *Function {
 	fn := &Function{
+		Architectures:     c.Architectures,
 		Description:       c.Description,
 		FunctionName:      c.FunctionName,
 		Handler:           c.Handler,

--- a/test/function.json
+++ b/test/function.json
@@ -1,4 +1,8 @@
 {
+    "Architectures": [
+        "x86_64",
+        "arm64"
+    ],
     "Description": "hello function",
     "Environment": {
         "Variables": {


### PR DESCRIPTION
> Adds support for Lambda functions powered by AWS Graviton2 processors.
> Customers can now select the CPU architecture for their functions.
https://github.com/aws/aws-sdk-go/releases/tag/v1.40.52

