### PR TITLE
Fix an unexpected nil pointer dereference on initializing with not existed function name

### DIFF
--- a/init.go
+++ b/init.go
@@ -78,7 +78,7 @@ func (app *App) Init(opt InitOption) error {
 			return err
 		}
 	}
-	if aws.StringValue(res.Configuration.PackageType) == "Image" {
+	if res.Configuration != nil && aws.StringValue(res.Configuration.PackageType) == "Image" {
 		log.Printf("[debug] Image URL=%s", *res.Code.ImageUri)
 		fn.PackageType = aws.String("Image")
 		fn.Code = &lambda.FunctionCode{


### PR DESCRIPTION
Hi,

prior to this commit, it raises the nil pointer dereference when the user attempts to do `init` sub command with not existed function name, like the bellow;

```
2021/11/11 21:29:37 [info] lambroll v0.12.0
2021/11/11 21:29:37 [info] function test is not found
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x190e22d]

goroutine 1 [running]:
github.com/fujiwara/lambroll.(*App).Init(0xc00010c230, {0xc00045c740, 0xc0004d21c0})
        /home/runner/work/lambroll/lambroll/init.go:81 +0x5ed
main._main()
        /home/runner/work/lambroll/lambroll/cmd/lambroll/main.go:128 +0x4a4f
main.main()
        /home/runner/work/lambroll/lambroll/cmd/lambroll/main.go:17 +0x19
```

This commit fixes this complication by checking the response object's property existence.