### PR TITLE
Show difference in "Code" object of GetFunctionOutput

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -2,9 +2,6 @@ package lambroll
 
 import (
 	"fmt"
-	"log"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/kylelemons/godebug/diff"
 	"github.com/pkg/errors"
@@ -25,31 +22,23 @@ func (app *App) Diff(opt DiffOption) error {
 	name := *newFunc.FunctionName
 
 	var latest *lambda.FunctionConfiguration
+	var tags Tags
 	if res, err := app.lambda.GetFunction(&lambda.GetFunctionInput{
 		FunctionName: &name,
 	}); err != nil {
 		return errors.Wrapf(err, "failed to GetFunction %s", name)
 	} else {
 		latest = res.Configuration
-	}
-
-	arn := app.functionArn(name)
-	log.Printf("[debug] listing tags of %s", arn)
-	var tags Tags
-	if res, err := app.lambda.ListTags(&lambda.ListTagsInput{
-		Resource: aws.String(arn),
-	}); err != nil {
-		return errors.Wrap(err, "faled to list tags")
-	} else {
 		tags = res.Tags
 	}
+
 	latestFunc := newFuctionFrom(latest, tags)
 
 	latestJSON, _ := marshalJSON(latestFunc)
 	newJSON, _ := marshalJSON(newFunc)
 
 	if ds := diff.Diff(string(latestJSON), string(newJSON)); ds != "" {
-		fmt.Println("---", arn)
+		fmt.Println("---", app.functionArn(name))
 		fmt.Println("+++", *opt.FunctionFilePath)
 		fmt.Println(ds)
 	}

--- a/diff.go
+++ b/diff.go
@@ -31,8 +31,7 @@ func (app *App) Diff(opt DiffOption) error {
 		latest = res.Configuration
 		tags = res.Tags
 	}
-
-	latestFunc := newFuctionFrom(latest, tags)
+	latestFunc := newFunctionFrom(latest, tags)
 
 	latestJSON, _ := marshalJSON(latestFunc)
 	newJSON, _ := marshalJSON(newFunc)

--- a/diff.go
+++ b/diff.go
@@ -22,6 +22,8 @@ func (app *App) Diff(opt DiffOption) error {
 	name := *newFunc.FunctionName
 
 	var latest *lambda.FunctionConfiguration
+	var code *lambda.FunctionCodeLocation
+
 	var tags Tags
 	if res, err := app.lambda.GetFunction(&lambda.GetFunctionInput{
 		FunctionName: &name,
@@ -29,9 +31,10 @@ func (app *App) Diff(opt DiffOption) error {
 		return errors.Wrapf(err, "failed to GetFunction %s", name)
 	} else {
 		latest = res.Configuration
+		code = res.Code
 		tags = res.Tags
 	}
-	latestFunc := newFunctionFrom(latest, tags)
+	latestFunc := newFunctionFrom(latest, code, tags)
 
 	latestJSON, _ := marshalJSON(latestFunc)
 	newJSON, _ := marshalJSON(newFunc)

--- a/init.go
+++ b/init.go
@@ -70,7 +70,7 @@ func (app *App) Init(opt InitOption) error {
 		tags = res.Tags
 	}
 
-	fn := newFuctionFrom(c, tags)
+	fn := newFunctionFrom(c, tags)
 
 	if *opt.DownloadZip && res.Code != nil && *res.Code.RepositoryType == "S3" {
 		log.Printf("[info] downloading %s", FunctionZipFilename)

--- a/init.go
+++ b/init.go
@@ -70,19 +70,12 @@ func (app *App) Init(opt InitOption) error {
 		tags = res.Tags
 	}
 
-	fn := newFunctionFrom(c, tags)
+	fn := newFunctionFrom(c, res.Code, tags)
 
 	if *opt.DownloadZip && res.Code != nil && *res.Code.RepositoryType == "S3" {
 		log.Printf("[info] downloading %s", FunctionZipFilename)
 		if err := download(*res.Code.Location, FunctionZipFilename); err != nil {
 			return err
-		}
-	}
-	if res.Configuration != nil && aws.StringValue(res.Configuration.PackageType) == "Image" {
-		log.Printf("[debug] Image URL=%s", *res.Code.ImageUri)
-		fn.PackageType = aws.String("Image")
-		fn.Code = &lambda.FunctionCode{
-			ImageUri: res.Code.ImageUri,
 		}
 	}
 

--- a/lambroll.go
+++ b/lambroll.go
@@ -244,7 +244,7 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeL
 		}
 	}
 
-	if aws.StringValue(fn.PackageType) == "Image" && aws.StringValue(code.RepositoryType) == "ECR" {
+	if aws.StringValue(code.RepositoryType) == "ECR" || aws.StringValue(fn.PackageType) == "Image" {
 		log.Printf("[debug] Image URL=%s", *code.ImageUri)
 		fn.PackageType = aws.String("Image")
 		fn.Code = &lambda.FunctionCode{

--- a/lambroll.go
+++ b/lambroll.go
@@ -210,7 +210,7 @@ func fillDefaultValues(fn *Function) {
 	}
 }
 
-func newFunctionFrom(c *lambda.FunctionConfiguration, tags Tags) *Function {
+func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeLocation, tags Tags) *Function {
 	fn := &Function{
 		Architectures:     c.Architectures,
 		Description:       c.Description,
@@ -243,6 +243,15 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, tags Tags) *Function {
 			SecurityGroupIds: v.SecurityGroupIds,
 		}
 	}
+
+	if aws.StringValue(fn.PackageType) == "Image" && aws.StringValue(code.RepositoryType) == "ECR" {
+		log.Printf("[debug] Image URL=%s", *code.ImageUri)
+		fn.PackageType = aws.String("Image")
+		fn.Code = &lambda.FunctionCode{
+			ImageUri: code.ImageUri,
+		}
+	}
+
 	fn.Tags = tags
 
 	return fn

--- a/lambroll.go
+++ b/lambroll.go
@@ -210,7 +210,7 @@ func fillDefaultValues(fn *Function) {
 	}
 }
 
-func newFuctionFrom(c *lambda.FunctionConfiguration, tags Tags) *Function {
+func newFunctionFrom(c *lambda.FunctionConfiguration, tags Tags) *Function {
 	fn := &Function{
 		Architectures:     c.Architectures,
 		Description:       c.Description,

--- a/list.go
+++ b/list.go
@@ -32,7 +32,7 @@ func (app *App) List(opt ListOption) error {
 			if err != nil {
 				return errors.Wrap(err, "faled to list tags")
 			}
-			b, _ := marshalJSON(newFuctionFrom(c, res.Tags))
+			b, _ := marshalJSON(newFunctionFrom(c, res.Tags))
 			os.Stdout.Write(b)
 		}
 		if marker = res.NextMarker; marker == nil {

--- a/list.go
+++ b/list.go
@@ -32,7 +32,7 @@ func (app *App) List(opt ListOption) error {
 			if err != nil {
 				return errors.Wrap(err, "faled to list tags")
 			}
-			b, _ := marshalJSON(newFunctionFrom(c, res.Tags))
+			b, _ := marshalJSON(newFunctionFrom(c, nil, res.Tags))
 			os.Stdout.Write(b)
 		}
 		if marker = res.NextMarker; marker == nil {


### PR DESCRIPTION
# About

I found `lambroll diff` shows difference in ECR image configurations even when there is no difference actually.  This PR has some trivial amends like typo, but mainly intended to modify that behavior.

<details>
<summary> in 日本語 </summary>

`lambroll diff` が、変更がない時にもECRイメージの設定に差分があると表示していることを発見しました 。 このPRは、タイポなど些細な修正もありますが、主に上記の動作を修正することを目的としています。

</details>