### PR TITLE
Validate update code

### DIFF
--- a/create.go
+++ b/create.go
@@ -20,7 +20,7 @@ func (app *App) prepareFunctionCodeForDeploy(opt DeployOption, fn *Function) err
 		info    os.FileInfo
 	)
 
-	if aws.StringValue(fn.PackageType) == "Image" {
+	if aws.StringValue(fn.PackageType) == packageTypeImage {
 		if fn.Code == nil || fn.Code.ImageUri == nil {
 			return errors.New("PackageType=Image requires Code.ImageUri in function definition")
 		}

--- a/deploy.go
+++ b/deploy.go
@@ -83,7 +83,7 @@ func (app *App) Deploy(opt DeployOption) error {
 	}
 
 	log.Printf("[info] starting deploy function %s", *fn.FunctionName)
-	if _, err := app.lambda.GetFunction(&lambda.GetFunctionInput{
+	if current, err := app.lambda.GetFunction(&lambda.GetFunctionInput{
 		FunctionName: fn.FunctionName,
 	}); err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
@@ -92,6 +92,8 @@ func (app *App) Deploy(opt DeployOption) error {
 				return app.create(opt, fn)
 			}
 		}
+		return err
+	} else if err := validateUpdateFunction(current.Configuration, current.Code, fn); err != nil {
 		return err
 	}
 

--- a/diff.go
+++ b/diff.go
@@ -47,6 +47,10 @@ func (app *App) Diff(opt DiffOption) error {
 		fmt.Println(color.GreenString("+++" + *opt.FunctionFilePath))
 		fmt.Println(coloredDiff(ds))
 	}
+
+	if err := validateUpdateFunction(latest, code, newFunc); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/lambroll.go
+++ b/lambroll.go
@@ -278,3 +278,27 @@ func exportEnvFile(file string) error {
 	}
 	return nil
 }
+
+var errCannotUpdateImageAndZip = errors.New("cannot update function code between Image and Zip")
+
+func validateUpdateFunction(currentConf *lambda.FunctionConfiguration, currentCode *lambda.FunctionCodeLocation, newFn *lambda.CreateFunctionInput) error {
+	newCode := newFn.Code
+
+	// new=Image
+	if newCode != nil && newCode.ImageUri != nil || aws.StringValue(newFn.PackageType) == packageTypeImage {
+		// current=Zip
+		if currentCode == nil || currentCode.ImageUri == nil {
+			return errCannotUpdateImageAndZip
+		}
+	}
+
+	// current=Image
+	if currentCode != nil && currentCode.ImageUri != nil || aws.StringValue(currentConf.PackageType) == packageTypeImage {
+		// new=Zip
+		if newCode == nil || newCode.ImageUri == nil {
+			return errCannotUpdateImageAndZip
+		}
+	}
+
+	return nil
+}

--- a/lambroll.go
+++ b/lambroll.go
@@ -21,6 +21,7 @@ import (
 )
 
 const versionLatest = "$LATEST"
+const packageTypeImage = "Image"
 
 var retryPolicy = retry.Policy{
 	MinDelay: time.Second,
@@ -244,9 +245,9 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeL
 		}
 	}
 
-	if aws.StringValue(code.RepositoryType) == "ECR" || aws.StringValue(fn.PackageType) == "Image" {
+	if aws.StringValue(code.RepositoryType) == "ECR" || aws.StringValue(fn.PackageType) == packageTypeImage {
 		log.Printf("[debug] Image URL=%s", *code.ImageUri)
-		fn.PackageType = aws.String("Image")
+		fn.PackageType = aws.String(packageTypeImage)
 		fn.Code = &lambda.FunctionCode{
 			ImageUri: code.ImageUri,
 		}


### PR DESCRIPTION
Fix for #205 .

AWS Lambda cannot change code type from Image to Zip and Zip to Image.
Validates these changes before deploy and diff.