### PR TITLE
Fix unexpected nil dereference when it runs `lambroll init` for not-existed function

### DIFF
--- a/lambroll.go
+++ b/lambroll.go
@@ -245,7 +245,7 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeL
 		}
 	}
 
-	if aws.StringValue(code.RepositoryType) == "ECR" || aws.StringValue(fn.PackageType) == packageTypeImage {
+	if (code != nil && aws.StringValue(code.RepositoryType) == "ECR") || aws.StringValue(fn.PackageType) == packageTypeImage {
 		log.Printf("[debug] Image URL=%s", *code.ImageUri)
 		fn.PackageType = aws.String(packageTypeImage)
 		fn.Code = &lambda.FunctionCode{


### PR DESCRIPTION
Previously it raises the error like the following:

```
$ lambroll init --function-name __NOT_EXISTS_FUNC__
2021/12/21 14:27:11 [info] lambroll v0.12.6
2021/12/21 14:27:12 [info] function __NOT_EXISTS_FUNC__ is not found
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x190c412]

goroutine 1 [running]:
github.com/fujiwara/lambroll.newFunctionFrom(0xc00099f7c0, 0x0, 0x0)
        /home/runner/work/lambroll/lambroll/lambroll.go:248 +0x432
github.com/fujiwara/lambroll.(*App).Init(0xc0000c0280, {0xc0003f6750, 0xc0004a0601})
        /home/runner/work/lambroll/lambroll/init.go:73 +0x4f5
main._main()
        /home/runner/work/lambroll/lambroll/cmd/lambroll/main.go:142 +0x4e0f
main.main()
        /home/runner/work/lambroll/lambroll/cmd/lambroll/main.go:19 +0x19
```

This patch fixes that unexpected nil dereference:

```
$ lambroll init --function-name __NOT_EXISTS_FUNC__
2021/12/21 14:59:19 [info] lambroll v0.12.0-28-g73ebdbe
2021/12/21 14:59:20 [info] function __NOT_EXISTS_FUNC__ is not found
2021/12/21 14:59:20 [info] creating .lambdaignore
2021/12/21 14:59:20 [info] creating function.json
2021/12/21 14:59:20 [info] completed
```