### PR TITLE
implements for diff --code

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -17,9 +17,11 @@ import (
 
 // Archive archives zip
 func (app *App) Archive(opt DeployOption) error {
-	if err := (&opt).Expand(); err != nil {
-		return errors.Wrap(err, "failed to validate deploy options")
+	excludes, err := expandExcludeFile(*opt.ExcludeFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse exclude file")
 	}
+	opt.Excludes = append(opt.Excludes, excludes...)
 
 	zipfile, _, err := createZipArchive(*opt.Src, opt.Excludes)
 	if err != nil {

--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -97,9 +97,12 @@ func _main() int {
 		FilterPattern:    logs.Flag("filter-pattern", "The filter  pattern to use").Default("").String(),
 	}
 
-	kingpin.Command("diff", "show display diff of function.json compared with latest function")
+	diff := kingpin.Command("diff", "show display diff of function.json compared with latest function")
 	diffOption := lambroll.DiffOption{
 		FunctionFilePath: function,
+		CodeSha256:       diff.Flag("code-sha256", "diff of code sha256").Default("false").Bool(),
+		ExcludeFile:      diff.Flag("exclude-file", "exclude file").Default(lambroll.IgnoreFilename).String(),
+		Src:              diff.Flag("src", "function zip archive or src dir").Default(".").String(),
 	}
 
 	versions := kingpin.Command("versions", "manage function versions")

--- a/cmd/lambroll/main.go
+++ b/cmd/lambroll/main.go
@@ -101,7 +101,7 @@ func _main() int {
 	diff := kingpin.Command("diff", "show display diff of function.json compared with latest function")
 	diffOption := lambroll.DiffOption{
 		FunctionFilePath: function,
-		CodeSha256:       diff.Flag("code-sha256", "diff of code sha256").Default("false").Bool(),
+		CodeSha256:       diff.Flag("code", "diff of code sha256").Default("false").Bool(),
 		ExcludeFile:      diff.Flag("exclude-file", "exclude file").Default(lambroll.IgnoreFilename).String(),
 		Src:              diff.Flag("src", "function zip archive or src dir").Default(".").String(),
 	}

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -16,10 +16,11 @@ func TestDeployOptionExpand(t *testing.T) {
 	opt := lambroll.DeployOption{
 		ExcludeFile: &file,
 	}
-	err := (&opt).Expand()
+	excludes, err := lambroll.ExpandExcludeFile(*opt.ExcludeFile)
 	if err != nil {
 		t.Error("failed to expand", err)
 	}
+	opt.Excludes = append(opt.Excludes, excludes...)
 	if len(opt.Excludes) != len(expectExcludes) {
 		t.Errorf("unexpeted expanded excludes %#v", opt.Excludes)
 	}

--- a/diff.go
+++ b/diff.go
@@ -1,9 +1,13 @@
 package lambroll
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/fatih/color"
 	"github.com/kylelemons/godebug/diff"
@@ -13,10 +17,20 @@ import (
 // DiffOption represents options for Diff()
 type DiffOption struct {
 	FunctionFilePath *string
+	Src              *string
+	Excludes         []string
+	CodeSha256       *bool
+	ExcludeFile      *string
 }
 
 // Diff prints diff of function.json compared with latest function
 func (app *App) Diff(opt DiffOption) error {
+	excludes, err := expandExcludeFile(*opt.ExcludeFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse exclude-file")
+	}
+	opt.Excludes = append(opt.Excludes, excludes...)
+
 	newFunc, err := app.loadFunction(*opt.FunctionFilePath)
 	if err != nil {
 		return errors.Wrap(err, "failed to load function")
@@ -28,6 +42,7 @@ func (app *App) Diff(opt DiffOption) error {
 	var code *lambda.FunctionCodeLocation
 
 	var tags Tags
+	var currentCodeSha256 string
 	if res, err := app.lambda.GetFunction(&lambda.GetFunctionInput{
 		FunctionName: &name,
 	}); err != nil {
@@ -36,6 +51,7 @@ func (app *App) Diff(opt DiffOption) error {
 		latest = res.Configuration
 		code = res.Code
 		tags = res.Tags
+		currentCodeSha256 = *res.Configuration.CodeSha256
 	}
 	latestFunc := newFunctionFrom(latest, code, tags)
 
@@ -51,6 +67,25 @@ func (app *App) Diff(opt DiffOption) error {
 	if err := validateUpdateFunction(latest, code, newFunc); err != nil {
 		return err
 	}
+
+	if aws.BoolValue(opt.CodeSha256) {
+		zipfile, _, err := createZipArchive(*opt.Src, opt.Excludes)
+		if err != nil {
+			return err
+		}
+		h := sha256.New()
+		if _, err := io.Copy(h, zipfile); err != nil {
+			return err
+		}
+		newCodeSha256 := base64.StdEncoding.EncodeToString(h.Sum(nil))
+		prefix := "CodeSha256: "
+		if ds := diff.Diff(prefix+currentCodeSha256, prefix+newCodeSha256); ds != "" {
+			fmt.Println(color.RedString("---" + app.functionArn(name)))
+			fmt.Println(color.GreenString("+++" + "--src=" + *opt.Src))
+			fmt.Println(coloredDiff(ds))
+		}
+	}
+
 	return nil
 }
 

--- a/diff.go
+++ b/diff.go
@@ -73,7 +73,7 @@ func (app *App) Diff(opt DiffOption) error {
 		if strings.ToLower(packageType) != "zip" {
 			return errors.New("code-sha256 is only supported for Zip package type")
 		}
-		zipfile, err := prepareZipfile(*opt.Src, opt.Excludes)
+		zipfile, _, err := prepareZipfile(*opt.Src, opt.Excludes)
 		if err != nil {
 			return err
 		}

--- a/export_test.go
+++ b/export_test.go
@@ -1,7 +1,8 @@
 package lambroll
 
 var (
-	CreateZipArchive = createZipArchive
-	LoadZipArchive   = loadZipArchive
-	MergeTags        = mergeTags
+	CreateZipArchive  = createZipArchive
+	ExpandExcludeFile = expandExcludeFile
+	LoadZipArchive    = loadZipArchive
+	MergeTags         = mergeTags
 )


### PR DESCRIPTION
refs #231

Add an option `--code` to `lambroll diff`.

When `--code` is specified, `lambroll diff` creates a zip archive (same as deploy) and compares SHA256 of the zip file with deployed function code.

Example output below. 

```console
$ lambroll diff --code
2022/06/11 00:29:15 [info] lambroll v0.12.9-9-g581c6e8 with function.jsonnet
2022/06/11 00:29:15 [info] creating zip archive from .
2022/06/11 00:29:15 [info] zip archive wrote 1507 bytes
---arn:aws:lambda:ap-northeast-1:123456789012:function:hello
+++--src=.
-CodeSha256: SBWSSbhCba1yFBavBm5f+OcT8aNQqXSi9QasYTgCZBo=
+CodeSha256: xQRnIP7CNPA4Ohb5xEj7KyDhkAAb2VfwBU4Oxw4/1Ac=

```