### PR TITLE
Fill default values to CreateFunctionInput before deploy.

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -96,6 +96,7 @@ func (app *App) Deploy(opt DeployOption) error {
 	} else if err := validateUpdateFunction(current.Configuration, current.Code, fn); err != nil {
 		return err
 	}
+	fillDefaultValues(fn)
 
 	if err := app.prepareFunctionCodeForDeploy(opt, fn); err != nil {
 		return errors.Wrap(err, "failed to prepare function code for deploy")


### PR DESCRIPTION
refs #242 

## description

For example, If "EphemeralStorage" is not defined in function.json, `lambroll diff` shows a difference of "EphemeralStorage" if a deployed function has a non-default value (e.g. Size != 512).

But `lambroll deploy` do not fill these default values before deployment.

So these differences may not be applied.

## fixes

Fill default values to CreateFunctionInput before do deploy.