### PR TITLE
fill ImageConfig on init

### DIFF
--- a/lambroll.go
+++ b/lambroll.go
@@ -266,6 +266,13 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeL
 			Variables: e.Variables,
 		}
 	}
+	if i := c.ImageConfigResponse.ImageConfig; i != nil {
+		fn.ImageConfig = &lambda.ImageConfig{
+			Command:          i.Command,
+			EntryPoint:       i.EntryPoint,
+			WorkingDirectory: i.WorkingDirectory,
+		}
+	}
 	for _, layer := range c.Layers {
 		fn.Layers = append(fn.Layers, layer.Arn)
 	}

--- a/lambroll.go
+++ b/lambroll.go
@@ -266,11 +266,11 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeL
 			Variables: e.Variables,
 		}
 	}
-	if i := c.ImageConfigResponse.ImageConfig; i != nil {
+	if i := c.ImageConfigResponse; i != nil {
 		fn.ImageConfig = &lambda.ImageConfig{
-			Command:          i.Command,
-			EntryPoint:       i.EntryPoint,
-			WorkingDirectory: i.WorkingDirectory,
+			Command:          i.ImageConfig.Command,
+			EntryPoint:       i.ImageConfig.EntryPoint,
+			WorkingDirectory: i.ImageConfig.WorkingDirectory,
 		}
 	}
 	for _, layer := range c.Layers {


### PR DESCRIPTION
`function.json` created by `lambda init` is missing `ImageConfig` field. This patch fills it.
I referred to [documentation of AWS Lambda `GetFunction` Response Syntax](https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html).

I test this patch can deploy successfully in my development environment.
`ImageConfig` field in `function.json` is like this.

```
{
...
  "ImageConfig": {
    "Command": [
      "cmd"
    ],
    "EntryPoint": [
      "/app"
    ],
    "WorkingDirectory": "/var/task"
  },
...
}
```

When `WorkingDirectory` is not configured, `GetFunction` returns an empty string.

```
{
...
   "ImageConfig": {
     "Command": [
       "cmd"
     ],
     "EntryPoint": [
       "/app"
     ],
     "WorkingDirectory": ""
   },
...
}
```

Even in that case, `lambroll deploy` can deploy Lambda functions without problems.

![Image_Configuration_AWS_Lambda_empty_workdir](https://github.com/chaya2z/lambroll/assets/58199341/c6142d75-ac5a-4c5a-bcf7-f3310afcc1c0)

---

Ref PR: https://github.com/fujiwara/lambroll/pull/101

Thank you!
