### PR TITLE
reset ImageConfig explicitly when it is removed.

### DIFF
--- a/create.go
+++ b/create.go
@@ -40,6 +40,10 @@ func (app *App) prepareFunctionCodeForDeploy(opt DeployOption, fn *Function) err
 		}
 		// deploy docker image. no need to preprare
 		log.Printf("[info] using docker image %s", *fn.Code.ImageUri)
+
+		if fn.ImageConfig == nil {
+			fn.ImageConfig = &lambda.ImageConfig{} // reset implicitly
+		}
 		return nil
 	}
 

--- a/create.go
+++ b/create.go
@@ -42,7 +42,7 @@ func (app *App) prepareFunctionCodeForDeploy(opt DeployOption, fn *Function) err
 		log.Printf("[info] using docker image %s", *fn.Code.ImageUri)
 
 		if fn.ImageConfig == nil {
-			fn.ImageConfig = &lambda.ImageConfig{} // reset implicitly
+			fn.ImageConfig = &lambda.ImageConfig{} // reset explicitly
 		}
 		return nil
 	}


### PR DESCRIPTION
fix for #307.

It became to reset the `ImageConfig` at `lambroll deploy`.

