### PR TITLE
Add runtime to output of versions command.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
         id: go
@@ -37,6 +37,8 @@ jobs:
           echo $PATH
           make clean
           make test
+        env:
+          TZ: Asia/Tokyo
 
       - name: create test
         run: |

--- a/export_test.go
+++ b/export_test.go
@@ -6,3 +6,6 @@ var (
 	LoadZipArchive    = loadZipArchive
 	MergeTags         = mergeTags
 )
+
+type VersionsOutput = versionsOutput
+type VersionsOutputs = versionsOutputs

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fujiwara/logutils v1.1.0
 	github.com/fujiwara/tfstate-lookup v0.4.2
 	github.com/go-test/deep v1.0.7
+	github.com/google/go-cmp v0.5.9
 	github.com/google/go-jsonnet v0.17.0
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e
 	github.com/kayac/go-config v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,9 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-jsonnet v0.17.0 h1:/9NIEfhK1NQRKl3sP2536b2+x5HnZMdql7x3yK/l8JY=
 github.com/google/go-jsonnet v0.17.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -528,7 +529,6 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/versions.go
+++ b/versions.go
@@ -62,12 +62,12 @@ func (vo versionsOutputs) Table() string {
 }
 
 func (v versionsOutput) TSV() string {
-	return fmt.Sprintf("%s\t%s\t%s\t%s\n",
+	return strings.Join([]string{
 		v.Version,
 		v.LastModified.Local().Format(time.RFC3339),
 		strings.Join(v.Aliases, ","),
 		v.Runtime,
-	)
+	}, "\t") + "\n"
 }
 
 // Versions manages the versions of a Lambda function

--- a/versions.go
+++ b/versions.go
@@ -25,6 +25,7 @@ type versionsOutput struct {
 	Version      string    `json:"Version"`
 	Aliases      []string  `json:"Aliases,omitempty"`
 	LastModified time.Time `json:"LastModified"`
+	Runtime      string    `json:"Runtime"`
 }
 
 type versionsOutputs []versionsOutput
@@ -47,19 +48,25 @@ func (vo versionsOutputs) TSV() string {
 func (vo versionsOutputs) Table() string {
 	buf := new(strings.Builder)
 	w := tablewriter.NewWriter(buf)
-	w.SetHeader([]string{"Version", "Last Modified", "Aliases"})
+	w.SetHeader([]string{"Version", "Last Modified", "Aliases", "Runtime"})
 	for _, v := range vo {
-		w.Append([]string{v.Version, v.LastModified.Local().Format(time.RFC3339), strings.Join(v.Aliases, ",")})
+		w.Append([]string{
+			v.Version,
+			v.LastModified.Local().Format(time.RFC3339),
+			strings.Join(v.Aliases, ","),
+			v.Runtime,
+		})
 	}
 	w.Render()
 	return buf.String()
 }
 
 func (v versionsOutput) TSV() string {
-	return fmt.Sprintf("%s\t%s\t%s\n",
+	return fmt.Sprintf("%s\t%s\t%s\t%s\n",
 		v.Version,
 		v.LastModified.Local().Format(time.RFC3339),
 		strings.Join(v.Aliases, ","),
+		v.Runtime,
 	)
 }
 
@@ -127,6 +134,7 @@ func (app *App) Versions(opt VersionsOption) error {
 			Version:      *v.Version,
 			Aliases:      aliases[*v.Version],
 			LastModified: lm,
+			Runtime:      *v.Runtime,
 		})
 	}
 

--- a/versions_test.go
+++ b/versions_test.go
@@ -33,6 +33,7 @@ func TestVersionsJSON(t *testing.T) {
 }
 
 func TestVersionsTSV(t *testing.T) {
+	t.Setenv("TZ", "UTC+9")
 	expectedTSV := "1\t2023-08-30T12:34:56+09:00\t\tgo1.x\n" +
 		"2\t2023-08-30T12:34:56+09:00\tcurrent,latest\tpython3.8\n"
 
@@ -42,6 +43,7 @@ func TestVersionsTSV(t *testing.T) {
 }
 
 func TestVersionsTable(t *testing.T) {
+	t.Setenv("TZ", "UTC+9")
 	tableOutput := TestVersionsOutputs.Table()
 	expectedOutput := `
 +---------+---------------------------+----------------+-----------+

--- a/versions_test.go
+++ b/versions_test.go
@@ -1,0 +1,59 @@
+package lambroll_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/fujiwara/lambroll"
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestFixedTime is a fixed time for testing (JST)
+var TestFixedTime = time.Date(2023, 8, 30, 12, 34, 56, 0, time.FixedZone("Asia/Tokyo", 9*60*60))
+
+var TestVersionsOutputs = lambroll.VersionsOutputs{
+	{Version: "1", LastModified: TestFixedTime, Runtime: "go1.x"},
+	{Version: "2", LastModified: TestFixedTime, Runtime: "python3.8", Aliases: []string{"current", "latest"}},
+}
+
+func TestVersionsJSON(t *testing.T) {
+	jsonOutput := TestVersionsOutputs.JSON()
+
+	var parsedOutputs lambroll.VersionsOutputs
+	err := json.Unmarshal([]byte(jsonOutput), &parsedOutputs)
+
+	if err != nil {
+		t.Errorf("Failed to unmarshal JSON: %s", err)
+	}
+
+	if d := cmp.Diff(parsedOutputs, TestVersionsOutputs); d != "" {
+		t.Errorf("JSON mismatch: diff:%s", d)
+	}
+}
+
+func TestVersionsTSV(t *testing.T) {
+	expectedTSV := "1\t2023-08-30T12:34:56+09:00\t\tgo1.x\n" +
+		"2\t2023-08-30T12:34:56+09:00\tcurrent,latest\tpython3.8\n"
+
+	if d := cmp.Diff(TestVersionsOutputs.TSV(), expectedTSV); d != "" {
+		t.Errorf("TSV mismatch: diff:%s", d)
+	}
+}
+
+func TestVersionsTable(t *testing.T) {
+	tableOutput := TestVersionsOutputs.Table()
+	expectedOutput := `
++---------+---------------------------+----------------+-----------+
+| VERSION |       LAST MODIFIED       |    ALIASES     |  RUNTIME  |
++---------+---------------------------+----------------+-----------+
+|       1 | 2023-08-30T12:34:56+09:00 |                | go1.x     |
+|       2 | 2023-08-30T12:34:56+09:00 | current,latest | python3.8 |
++---------+---------------------------+----------------+-----------+
+`
+	expectedOutput = expectedOutput[1:] // remove first newline
+
+	if d := cmp.Diff(tableOutput, expectedOutput); d != "" {
+		t.Errorf("Table mismatch: diff:%s", d)
+	}
+}


### PR DESCRIPTION
Add `runtime` into the output of `lambroll version`.

For example,
```
+---------+---------------------------+---------+--------------+
| VERSION |       LAST MODIFIED       | ALIASES |   RUNTIME    |
+---------+---------------------------+---------+--------------+
|       1 | 2022-01-20T23:14:36+09:00 |         | provided.al2 |
|       2 | 2023-03-05T14:34:24+09:00 | current | provided.al2 |
+---------+---------------------------+---------+--------------+
```