### PR TITLE
Add $LATEST and Package Type into `versions` command output.

### DIFF
--- a/versions.go
+++ b/versions.go
@@ -25,6 +25,7 @@ type versionsOutput struct {
 	Version      string    `json:"Version"`
 	Aliases      []string  `json:"Aliases,omitempty"`
 	LastModified time.Time `json:"LastModified"`
+	PackageType  string    `json:"PackageType"`
 	Runtime      string    `json:"Runtime"`
 }
 
@@ -48,12 +49,13 @@ func (vo versionsOutputs) TSV() string {
 func (vo versionsOutputs) Table() string {
 	buf := new(strings.Builder)
 	w := tablewriter.NewWriter(buf)
-	w.SetHeader([]string{"Version", "Last Modified", "Aliases", "Runtime"})
+	w.SetHeader([]string{"Version", "Last Modified", "Aliases", "Package Type", "Runtime"})
 	for _, v := range vo {
 		w.Append([]string{
 			v.Version,
 			v.LastModified.Local().Format(time.RFC3339),
 			strings.Join(v.Aliases, ","),
+			v.PackageType,
 			v.Runtime,
 		})
 	}
@@ -66,6 +68,7 @@ func (v versionsOutput) TSV() string {
 		v.Version,
 		v.LastModified.Local().Format(time.RFC3339),
 		strings.Join(v.Aliases, ","),
+		v.PackageType,
 		v.Runtime,
 	}, "\t") + "\n"
 }
@@ -134,7 +137,8 @@ func (app *App) Versions(opt VersionsOption) error {
 			Version:      *v.Version,
 			Aliases:      aliases[*v.Version],
 			LastModified: lm,
-			Runtime:      *v.Runtime,
+			PackageType:  aws.StringValue(v.PackageType),
+			Runtime:      aws.StringValue(v.Runtime),
 		})
 	}
 

--- a/versions.go
+++ b/versions.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -125,10 +127,20 @@ func (app *App) Versions(opt VersionsOption) error {
 	}
 
 	vo := make(versionsOutputs, 0, len(versions))
-	for _, v := range versions {
-		if aws.StringValue(v.Version) == versionLatest {
-			continue
+	// sort by version asc
+	sort.Slice(versions, func(i, j int) bool {
+		iv, _ := strconv.Atoi(*versions[i].Version)
+		if *versions[i].Version == "$LATEST" {
+			iv = 2147483647 // max int32
 		}
+		jv, _ := strconv.Atoi(*versions[j].Version)
+		if *versions[j].Version == "$LATEST" {
+			jv = 2147483647 // max int32
+		}
+		return iv < jv
+	})
+
+	for _, v := range versions {
 		lm, err := time.Parse("2006-01-02T15:04:05.999-0700", *v.LastModified)
 		if err != nil {
 			return errors.Wrap(err, "failed to parse last modified")

--- a/versions_test.go
+++ b/versions_test.go
@@ -2,6 +2,7 @@ package lambroll_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ var TestFixedTime = time.Date(2023, 8, 30, 12, 34, 56, 0, time.FixedZone("Asia/T
 var TestVersionsOutputs = lambroll.VersionsOutputs{
 	{Version: "1", LastModified: TestFixedTime, PackageType: "Zip", Runtime: "provided.al2"},
 	{Version: "2", LastModified: TestFixedTime, PackageType: "Image", Runtime: "", Aliases: []string{"current", "latest"}},
+	{Version: "$LATEST", LastModified: TestFixedTime, PackageType: "Zip", Runtime: "provided.al2"},
 }
 
 func TestVersionsJSON(t *testing.T) {
@@ -34,8 +36,12 @@ func TestVersionsJSON(t *testing.T) {
 
 func TestVersionsTSV(t *testing.T) {
 	t.Setenv("TZ", "UTC+9")
-	expectedTSV := "1\t2023-08-30T12:34:56+09:00\t\tZip\tprovided.al2\n" +
-		"2\t2023-08-30T12:34:56+09:00\tcurrent,latest\tImage\t\n"
+	expectedTSV := strings.Join([]string{
+		"1\t2023-08-30T12:34:56+09:00\t\tZip\tprovided.al2",
+		"2\t2023-08-30T12:34:56+09:00\tcurrent,latest\tImage\t",
+		"$LATEST\t2023-08-30T12:34:56+09:00\t\tZip\tprovided.al2",
+	}, "\n")
+	expectedTSV += "\n"
 
 	if d := cmp.Diff(TestVersionsOutputs.TSV(), expectedTSV); d != "" {
 		t.Errorf("TSV mismatch: diff:%s", d)
@@ -51,6 +57,7 @@ func TestVersionsTable(t *testing.T) {
 +---------+---------------------------+----------------+--------------+--------------+
 |       1 | 2023-08-30T12:34:56+09:00 |                | Zip          | provided.al2 |
 |       2 | 2023-08-30T12:34:56+09:00 | current,latest | Image        |              |
+| $LATEST | 2023-08-30T12:34:56+09:00 |                | Zip          | provided.al2 |
 +---------+---------------------------+----------------+--------------+--------------+
 `
 	expectedOutput = expectedOutput[1:] // remove first newline

--- a/versions_test.go
+++ b/versions_test.go
@@ -13,8 +13,8 @@ import (
 var TestFixedTime = time.Date(2023, 8, 30, 12, 34, 56, 0, time.FixedZone("Asia/Tokyo", 9*60*60))
 
 var TestVersionsOutputs = lambroll.VersionsOutputs{
-	{Version: "1", LastModified: TestFixedTime, Runtime: "go1.x"},
-	{Version: "2", LastModified: TestFixedTime, Runtime: "python3.8", Aliases: []string{"current", "latest"}},
+	{Version: "1", LastModified: TestFixedTime, PackageType: "Zip", Runtime: "provided.al2"},
+	{Version: "2", LastModified: TestFixedTime, PackageType: "Image", Runtime: "", Aliases: []string{"current", "latest"}},
 }
 
 func TestVersionsJSON(t *testing.T) {
@@ -34,8 +34,8 @@ func TestVersionsJSON(t *testing.T) {
 
 func TestVersionsTSV(t *testing.T) {
 	t.Setenv("TZ", "UTC+9")
-	expectedTSV := "1\t2023-08-30T12:34:56+09:00\t\tgo1.x\n" +
-		"2\t2023-08-30T12:34:56+09:00\tcurrent,latest\tpython3.8\n"
+	expectedTSV := "1\t2023-08-30T12:34:56+09:00\t\tZip\tprovided.al2\n" +
+		"2\t2023-08-30T12:34:56+09:00\tcurrent,latest\tImage\t\n"
 
 	if d := cmp.Diff(TestVersionsOutputs.TSV(), expectedTSV); d != "" {
 		t.Errorf("TSV mismatch: diff:%s", d)
@@ -46,12 +46,12 @@ func TestVersionsTable(t *testing.T) {
 	t.Setenv("TZ", "UTC+9")
 	tableOutput := TestVersionsOutputs.Table()
 	expectedOutput := `
-+---------+---------------------------+----------------+-----------+
-| VERSION |       LAST MODIFIED       |    ALIASES     |  RUNTIME  |
-+---------+---------------------------+----------------+-----------+
-|       1 | 2023-08-30T12:34:56+09:00 |                | go1.x     |
-|       2 | 2023-08-30T12:34:56+09:00 | current,latest | python3.8 |
-+---------+---------------------------+----------------+-----------+
++---------+---------------------------+----------------+--------------+--------------+
+| VERSION |       LAST MODIFIED       |    ALIASES     | PACKAGE TYPE |   RUNTIME    |
++---------+---------------------------+----------------+--------------+--------------+
+|       1 | 2023-08-30T12:34:56+09:00 |                | Zip          | provided.al2 |
+|       2 | 2023-08-30T12:34:56+09:00 | current,latest | Image        |              |
++---------+---------------------------+----------------+--------------+--------------+
 `
 	expectedOutput = expectedOutput[1:] // remove first newline
 


### PR DESCRIPTION
This PR adds $LATEST version and package type into `versions` command output.

```
+---------+---------------------------+---------+--------------+--------------+
| VERSION |       LAST MODIFIED       | ALIASES | PACKAGE TYPE |   RUNTIME    |
+---------+---------------------------+---------+--------------+--------------+
|       3 | 2023-09-04T14:21:47+09:00 |         | Zip          | provided.al2 |
|       4 | 2023-09-04T14:22:25+09:00 | current | Zip          | provided.al2 |
| $LATEST | 2023-09-04T14:28:04+09:00 |         | Zip          | provided.al2 |
+---------+---------------------------+---------+--------------+--------------+
```

```
+---------+---------------------------+---------+--------------+---------+
| VERSION |       LAST MODIFIED       | ALIASES | PACKAGE TYPE | RUNTIME |
+---------+---------------------------+---------+--------------+---------+
|       5 | 2022-03-30T17:59:11+09:00 |         | Image        |         |
|       6 | 2022-04-07T16:03:17+09:00 | current | Image        |         |
| $LATEST | 2022-04-07T16:03:17+09:00 |         | Image        |         |
+---------+---------------------------+---------+--------------+---------+
```