### PR TITLE
Wait until the function code has been successfully updated

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -213,9 +213,11 @@ func (app *App) updateFunctionCode(ctx context.Context, in *lambda.UpdateFunctio
 		return nil, err
 	}
 
+	var res *lambda.FunctionConfiguration
 	retrier := retryPolicy.Start(ctx)
 	for retrier.Continue() {
-		res, err := app.lambda.UpdateFunctionCodeWithContext(ctx, in)
+		var err error
+		res, err = app.lambda.UpdateFunctionCodeWithContext(ctx, in)
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok {
 				switch aerr.Code() {
@@ -226,10 +228,20 @@ func (app *App) updateFunctionCode(ctx context.Context, in *lambda.UpdateFunctio
 			}
 			return nil, errors.Wrap(err, "failed to update function code")
 		}
-		log.Println("[info] updated function code successfully")
-		return res, nil
+		log.Println("[info] update function code request was accepted")
+		break
 	}
-	return nil, errors.New("failed to update function code (max retries reached)")
+
+	if !retrier.Continue() {
+		return nil, errors.New("failed to update function code (max retries reached)")
+	}
+
+	if err := app.waitForLastUpdateStatusSuccessful(ctx, *in.FunctionName); err != nil {
+		return nil, err
+	}
+	log.Println("[info] updated function code successfully")
+
+	return res, nil
 }
 
 func (app *App) waitForLastUpdateStatusSuccessful(ctx context.Context, name string) error {


### PR DESCRIPTION
Fixes #313

The current implementation does not wait `LastUpdateStatus` to be `Successful` after `UpdateFunctionCodeWithContext` call. This might not matter with small zip packages, but it does matter with large container images.

Note: I was wondering that updateFunctionConfiguration should also wait before returning, but I'm not sure adding redundant wait is acceptable, so I only fixed the updateFunctionCode as a minimum. If you prefer that the updateFunctionConfiguration should wait in the same way, please let me know.

deploy test logs with fixed version:

```
$ $GOPATH/bin/lambroll deploy --keep-versions=3
2023/09/21 01:42:40 [info] lambroll v0.14.3-6-g417d61c with function.json
2023/09/21 01:42:40 [info] starting deploy function foo
2023/09/21 01:42:40 [info] using docker image 012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/foo:latest
2023/09/21 01:42:40 [info] updating function configuration
2023/09/21 01:42:41 [info] State:Active LastUpdateStatus:Successful
2023/09/21 01:42:41 [info] updated function configuration successfully
2023/09/21 01:42:41 [info] updating function code
2023/09/21 01:42:41 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:42:41 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:42:42 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:42:42 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:42:44 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:42:44 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:42:48 [info] State:Active LastUpdateStatus:Successful
2023/09/21 01:42:49 [info] update function code request was accepted
2023/09/21 01:42:50 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:42:50 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:42:51 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:42:51 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:42:54 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:42:54 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:42:58 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:42:58 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:43:06 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:43:06 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:43:16 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:43:16 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:43:26 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:43:26 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:43:36 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:43:36 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:43:46 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:43:46 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:43:56 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:43:56 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:44:06 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:44:06 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:44:17 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:44:17 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:44:27 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:44:27 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:44:37 [info] State:Active LastUpdateStatus:InProgress
2023/09/21 01:44:37 [info] waiting for LastUpdateStatus Successful
2023/09/21 01:44:47 [info] State:Active LastUpdateStatus:Successful
2023/09/21 01:44:47 [info] updated function code successfully
2023/09/21 01:44:47 [info] deployed version 34
2023/09/21 01:44:47 [info] updating alias set current to version 34
2023/09/21 01:44:47 [info] alias updated
2023/09/21 01:44:47 [info] deleting function version: 31
2023/09/21 01:44:47 [info] except 3 latest versions are deleted
2023/09/21 01:44:47 [info] completed
```

```
$ while true ; do aws lambda get-function --function-name foo --query 'Configuration.[State, LastUpdateStatus]' | jq -c '[(now | todateiso8601)] + .'; sleep 1; done
["2023-09-21T01:42:37Z","Active","Successful"]
["2023-09-21T01:42:39Z","Active","Successful"]
["2023-09-21T01:42:41Z","Active","Successful"]
["2023-09-21T01:42:42Z","Active","InProgress"]
["2023-09-21T01:42:44Z","Active","InProgress"]
["2023-09-21T01:42:47Z","Active","Successful"]
["2023-09-21T01:42:48Z","Active","Successful"]
["2023-09-21T01:42:50Z","Active","InProgress"]
["2023-09-21T01:42:52Z","Active","InProgress"]
["2023-09-21T01:42:54Z","Active","InProgress"]
["2023-09-21T01:42:55Z","Active","InProgress"]
(snip.)
["2023-09-21T01:44:31Z","Active","InProgress"]
["2023-09-21T01:44:33Z","Active","InProgress"]
["2023-09-21T01:44:35Z","Active","InProgress"]
["2023-09-21T01:44:37Z","Active","InProgress"]
["2023-09-21T01:44:39Z","Active","InProgress"]
["2023-09-21T01:44:41Z","Active","Successful"]
["2023-09-21T01:44:42Z","Active","Successful"]
["2023-09-21T01:44:44Z","Active","Successful"]
["2023-09-21T01:44:46Z","Active","Successful"]
["2023-09-21T01:44:48Z","Active","Successful"]
```