### PR TITLE
fix: added zero value check for ImageConfigRespose

### DIFF
--- a/lambroll.go
+++ b/lambroll.go
@@ -267,7 +267,7 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeL
 			Variables: e.Variables,
 		}
 	}
-	if i := c.ImageConfigResponse; i != nil {
+	if i := c.ImageConfigResponse; i != nil && *i != (lambda.ImageConfigResponse{}) {
 		fn.ImageConfig = &lambda.ImageConfig{
 			Command:          i.ImageConfig.Command,
 			EntryPoint:       i.ImageConfig.EntryPoint,

--- a/lambroll.go
+++ b/lambroll.go
@@ -267,7 +267,7 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeL
 			Variables: e.Variables,
 		}
 	}
-	if i := c.ImageConfigResponse; i != nil && *i != (lambda.ImageConfigResponse{}) {
+	if i := c.ImageConfigResponse; i != nil && i.ImageConfig != nil {
 		fn.ImageConfig = &lambda.ImageConfig{
 			Command:          i.ImageConfig.Command,
 			EntryPoint:       i.ImageConfig.EntryPoint,


### PR DESCRIPTION
Hi, @fujiwara
I fixed an error that occurred when executing `lambroll init` command.

## Summary
Fixed an error that occurred when `Configuration.ImageConfigResponse` was empty (not nil).

```console
$ lambroll init --function-name=testtest
2023/10/18 12:50:24 [info] lambroll current with function.json
2023/10/18 12:50:24 [info] function testtest found
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104ea44fc]

goroutine 1 [running]:
github.com/fujiwara/lambroll.newFunctionFrom(0x1400048c140, 0x140004a0000, 0x14000489350)
        /Users/user/git/github.com/fujiwara/lambroll/lambroll.go:271 +0x26c
github.com/fujiwara/lambroll.(*App).Init(0x14000117270, {0x14000050340?, 0x140000114ad?})
        /Users/user/git/github.com/fujiwara/lambroll/init.go:73 +0x49c
main._main()
        /Users/user/git/github.com/fujiwara/lambroll/cmd/lambroll/main.go:146 +0x513c
main.main()
        /Users/user/git/github.com/fujiwara/lambroll/cmd/lambroll/main.go:19 +0x1c
exit status 2
```

## Background
When creating a Lambda function using docker, the `Configuration.ImageConfigResponse` value may return empty (not nil).

```console
$ aws lambda get-function --function-name testtest
{
	"Configuration": {
		"FunctionName": "testtest",
		"FunctionArn": "arn:aws:lambda:ap-northeast-1:000000000000:function:testtest",
		"Role": "arn:aws:iam::000000000000:role/service-role/testtest-role-fj3916tq",
		"CodeSize": 0,
		"Description": "",
		"Timeout": 3,
		"MemorySize": 128,
		"LastModified": "2023-10-18T03:27:57.850+0000",
		"CodeSha256": "a6aba231e5414b4a0a421167da89bdba84fa29d7de682390c90be28241f38463",
		"Version": "$LATEST",
		"TracingConfig": {
			"Mode": "PassThrough"
		},
		"RevisionId": "47bb563e-905c-4e48-984a-10346eb1b700",
		"State": "Active",
		"LastUpdateStatus": "Successful",
		"PackageType": "Image",
		"ImageConfigResponse": {},
		"Architectures": [
			"x86_64"
		],
		...omitted
}
```

It appears that when the "Image configuration" is reconfigured, the `Configuration.ImageConfigResponse` is not empty, but nil.

Function > Image configuration > Edit > Save
![image](https://github.com/fujiwara/lambroll/assets/29038315/dbb5209d-1e98-44e7-8626-b05811729954)

```console
{
	"Configuration": {
		"FunctionName": "testtest",
		"FunctionArn": "arn:aws:lambda:ap-northeast-1:000000000000:function:testtest",
		"Role": "arn:aws:iam::000000000000:role/service-role/testtest-role-fj3916tq",
		"CodeSize": 0,
		"Description": "",
		"Timeout": 3,
		"MemorySize": 128,
		"LastModified": "2023-10-18T03:27:57.850+0000",
		"CodeSha256": "a6aba231e5414b4a0a421167da89bdba84fa29d7de682390c90be28241f38463",
		"Version": "$LATEST",
		"TracingConfig": {
			"Mode": "PassThrough"
		},
		"RevisionId": "47bb563e-905c-4e48-984a-10346eb1b700",
		"State": "Active",
		"LastUpdateStatus": "Successful",
		"PackageType": "Image",
		"Architectures": [
			"x86_64"
		],
		...omitted
}
```

## Other
I am not familiar with golang, so my corrections may be inappropriate. In that case, close this PR or add commits.