### PR TITLE
fix failed to diff when a remote function is not found.

### DIFF
--- a/lambroll.go
+++ b/lambroll.go
@@ -258,7 +258,7 @@ func (app *App) loadFunction(path string) (*Function, error) {
 
 func newFunctionFrom(c *types.FunctionConfiguration, code *types.FunctionCodeLocation, tags Tags) *Function {
 	if c == nil {
-		return &Function{}
+		return nil
 	}
 	fn := &Function{
 		Architectures:     c.Architectures,
@@ -319,6 +319,9 @@ func newFunctionFrom(c *types.FunctionConfiguration, code *types.FunctionCodeLoc
 }
 
 func fillDefaultValues(fn *Function) {
+	if fn == nil {
+		return
+	}
 	if len(fn.Architectures) == 0 {
 		fn.Architectures = []types.Architecture{types.ArchitectureX8664}
 	}


### PR DESCRIPTION
newFunctionFrom() and fillDefaultValues() care the remote function configuration is not found.