### PR TITLE
Fix options for compatibility with previous versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ init function.json
 
 Flags:
       --function-name=                    Function name for init
-      --download-zip                      Download function.zip
+      --download                          Download function.zip
       --jsonnet                           render function.json as jsonnet
       --qualifier=QUALIFIER               function version or alias
       --function-url                      create function url definition file
@@ -220,7 +220,7 @@ deploy or create function
 Flags:
       --src="."                           function zip archive or src dir
       --publish                           publish function
-      --alias-name="current"              alias name for publish
+      --alias="current"                   alias name for publish
       --alias-to-latest                   set alias to unpublished $LATEST version
       --dry-run                           dry run
       --skip-archive                      skip to create zip archive. requires Code.S3Bucket and Code.S3Key in function

--- a/deploy.go
+++ b/deploy.go
@@ -20,7 +20,7 @@ import (
 type DeployOption struct {
 	Src           string `help:"function zip archive or src dir" default:"."`
 	Publish       bool   `help:"publish function" default:"true"`
-	AliasName     string `help:"alias name for publish" default:"current"`
+	AliasName     string `name:"alias" help:"alias name for publish" default:"current"`
 	AliasToLatest bool   `help:"set alias to unpublished $LATEST version" default:"false"`
 	DryRun        bool   `help:"dry run" default:"false"`
 	SkipArchive   bool   `help:"skip to create zip archive. requires Code.S3Bucket and Code.S3Key in function definition" default:"false"`

--- a/diff.go
+++ b/diff.go
@@ -23,7 +23,7 @@ import (
 // DiffOption represents options for Diff()
 type DiffOption struct {
 	Src         string  `help:"function zip archive or src dir" default:"."`
-	CodeSha256  bool    `help:"diff of code sha256" default:"false"`
+	CodeSha256  bool    `name:"code" help:"diff of code sha256" default:"false"`
 	Qualifier   *string `help:"the qualifier to compare"`
 	FunctionURL string  `help:"path to function-url definiton" default:"" env:"LAMBROLL_FUNCTION_URL"`
 	Ignore      string  `help:"ignore diff by jq query" default:""`

--- a/init.go
+++ b/init.go
@@ -18,7 +18,7 @@ import (
 // InitOption represents options for Init()
 type InitOption struct {
 	FunctionName *string `help:"Function name for init" required:"true" default:""`
-	DownloadZip  bool    `help:"Download function.zip" default:"false"`
+	DownloadZip  bool    `name:"download" help:"Download function.zip" default:"false"`
 	Jsonnet      bool    `default:"false" help:"render function.json as jsonnet"`
 	Qualifier    *string `help:"function version or alias"`
 	FunctionURL  bool    `help:"create function url definition file" default:"false"`


### PR DESCRIPTION
See: #357 

On v1.0.0, Some command flags are changed from v0.1.7 because of Kong's auto-generate feature. (#315)
Respect their former flag name and set them explicitly with `name:"..."` struct tag.