### PR TITLE
Support to `rollback --alias`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,16 +266,17 @@ rollback function
 
 Flags:
       --dry-run                           dry run
+      --alias="current"                   alias to rollback
       --delete-version                    delete rolled back version
 ```
 
-`lambroll deploy` create/update alias `current` to the published function version on deploy.
+`lambroll deploy` create/update alias to the published function version on deploy.
 
 `lambroll rollback` works as below.
 
-1. Find previous one version of function.
-2. Update alias `current` to the previous version.
-3. When `--delete-version` specified, delete old version of function.
+1. Find the previous version from the alias with no other aliases.
+2. Update the alias to the previous version.
+3. When `--delete-version` is specified, delete the old version of the function.
 
 ### Invoke
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ Flags:
    - If `--version` is specified, update the alias to the specified version.
 3. When `--delete-version` is specified, delete the old version of the function.
 
+If you add multiple aliases to the function, `lambroll rollback --alias={some-alias}` may not work as expected. Because the previous version that auto-detected may be the older version of other aliases.
+
+So you should specify the version to rollback with `--version` flag to clear the ambiguity.
+
 ### Invoke
 
 ```

--- a/README.md
+++ b/README.md
@@ -265,9 +265,10 @@ Usage: lambroll rollback
 rollback function
 
 Flags:
-      --dry-run                           dry run
-      --alias="current"                   alias to rollback
-      --delete-version                    delete rolled back version
+      --dry-run                   dry run
+      --alias="current"           alias to rollback
+      --version=""                version to rollback (default: previous version auto detected)
+      --delete-version            delete rolled back version
 ```
 
 `lambroll deploy` create/update alias to the published function version on deploy.
@@ -276,6 +277,7 @@ Flags:
 
 1. Find the previous version from the alias with no other aliases.
 2. Update the alias to the previous version.
+   - If `--version` is specified, update the alias to the specified version.
 3. When `--delete-version` is specified, delete the old version of the function.
 
 ### Invoke

--- a/rollback.go
+++ b/rollback.go
@@ -17,6 +17,7 @@ import (
 type RollbackOption struct {
 	DryRun        bool   `default:"false" help:"dry run"`
 	Alias         string `default:"current" help:"alias to rollback"`
+	Version       string `default:"" help:"version to rollback (default: previous version auto detected)"`
 	DeleteVersion bool   `default:"false" help:"delete rolled back version"`
 }
 
@@ -44,45 +45,15 @@ func (app *App) Rollback(ctx context.Context, opt *RollbackOption) error {
 		return fmt.Errorf("failed to get alias: %w", err)
 	}
 
-	aliases, err := app.getAliases(ctx, *fn.FunctionName)
-	if err != nil {
-		return fmt.Errorf("failed to get aliases: %w", err)
-	}
-
 	currentVersion := *res.FunctionVersion
-	cv, err := strconv.ParseInt(currentVersion, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to pase %s as int: %w", currentVersion, err)
-	}
-
 	var prevVersion string
-VERSIONS:
-	for v := cv - 1; v > 0; v-- {
-		log.Printf("[debug] get function version %d", v)
-		vs := strconv.FormatInt(v, 10)
-		res, err := app.lambda.GetFunction(ctx, &lambda.GetFunctionInput{
-			FunctionName: fn.FunctionName,
-			Qualifier:    aws.String(vs),
-		})
+	if opt.Version != "" {
+		prevVersion = opt.Version
+	} else {
+		prevVersion, err = app.findPreviousVersion(ctx, *fn.FunctionName, currentVersion)
 		if err != nil {
-			var nfe *types.ResourceNotFoundException
-			if errors.As(err, &nfe) {
-				log.Printf("[debug] version %s not found", vs)
-				continue VERSIONS
-			} else {
-				return fmt.Errorf("failed to get function: %w", err)
-			}
+			return fmt.Errorf("failed to find previous version: %w", err)
 		}
-		if pv := *res.Configuration.Version; aliases[pv] != nil {
-			// skip if the version has alias
-			log.Printf("[info] version %s has alias %v, skipping", pv, aliases[pv])
-			continue VERSIONS
-		}
-		prevVersion = *res.Configuration.Version
-		break
-	}
-	if prevVersion == "" {
-		return errors.New("unable to detect previous version of function")
 	}
 
 	log.Printf("[info] rollbacking function version %s to %s %s", currentVersion, prevVersion, opt.label())
@@ -99,6 +70,48 @@ VERSIONS:
 	}
 
 	return app.deleteFunctionVersion(ctx, *fn.FunctionName, currentVersion)
+}
+
+func (app *App) findPreviousVersion(ctx context.Context, name, currentVersion string) (string, error) {
+	aliases, err := app.getAliases(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("failed to get aliases: %w", err)
+	}
+	cv, err := strconv.ParseInt(currentVersion, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("failed to pase %s as int: %w", currentVersion, err)
+	}
+
+	var prevVersion string
+VERSIONS:
+	for v := cv - 1; v > 0; v-- {
+		log.Printf("[debug] get function version %d", v)
+		vs := strconv.FormatInt(v, 10)
+		res, err := app.lambda.GetFunction(ctx, &lambda.GetFunctionInput{
+			FunctionName: aws.String(name),
+			Qualifier:    aws.String(vs),
+		})
+		if err != nil {
+			var nfe *types.ResourceNotFoundException
+			if errors.As(err, &nfe) {
+				log.Printf("[debug] version %s not found", vs)
+				continue VERSIONS
+			} else {
+				return "", fmt.Errorf("failed to get function: %w", err)
+			}
+		}
+		if pv := *res.Configuration.Version; aliases[pv] != nil {
+			// skip if the version has alias
+			log.Printf("[info] version %s has alias %v, skipping", pv, aliases[pv])
+			continue VERSIONS
+		}
+		prevVersion = *res.Configuration.Version
+		break
+	}
+	if prevVersion == "" {
+		return "", fmt.Errorf("unable to detect previous version of function")
+	}
+	return prevVersion, nil
 }
 
 func (app *App) deleteFunctionVersion(ctx context.Context, functionName, version string) error {


### PR DESCRIPTION
refs #360 

Support `rollback --alias` flag to specify the alias to rollback.

Now, lambroll finds the target version to rollback by the logic as below.

- List all versions with the lower version of the alias to rollback.
- Pick the highest version number from these.
  - but If the version has aliases, continue to the next lower version.

But, this algorithm has a problem. The selected version may be the previous version of the other aliases.

To solve the problem, we have to detect all older versions for each deployed alias.
But I have no good idea to solve it.