### PR TITLE
Support CloudFront OAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,8 @@ See also [Restricting access to an AWS Lambda function URL origin](https://docs.
 
 If you need to allow access from any CloudFront distributions in your account, you can specify `SourceArn` as `arn:aws:cloudfront::123456789012:distribution/*`.
 
+Specifying `SourceArn` as `*` is not recommended because it allows access from any CloudFront distribution in any AWS account.
+
 ## LICENSE
 
 MIT License

--- a/README.md
+++ b/README.md
@@ -616,11 +616,13 @@ See also [Restricting access to an AWS Lambda function URL origin](https://docs.
   "Permissions": [
     {
       "Principal": "cloudfront.amazonaws.com",
-      "SourceArn": "arn:aws:cloudfront::123456789012:distribution/XXXXXXXXX"
+      "SourceArn": "arn:aws:cloudfront::123456789012:distribution/EXXXXXXXX"
     }
   ]
 }
 ```
+
+If you need to allow access from any CloudFront distributions in your account, you can specify `SourceArn` as `arn:aws:cloudfront::123456789012:distribution/*`.
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -568,8 +568,8 @@ When you want to deploy a private (requires AWS IAM authentication) function URL
 ```json
 {
   "Config": {
-   "AuthType": "AWS_IAM",
-   "Cors": {
+    "AuthType": "AWS_IAM",
+    "Cors": {
       "AllowOrigins": [
         "*"
       ],
@@ -599,6 +599,28 @@ When you want to deploy a private (requires AWS IAM authentication) function URL
   - When `AuthType` is `AWS_IAM`, you must define `Permissions` to specify allowed principals.
   - Each elements of `Permissions` maps to [AddPermissionInput](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/lambda#AddPermissionInput) in AWS SDK Go v2.
 - `function_url.jsonnet` is also supported like `function.jsonnet`.
+
+#### CloudFront origin access control (OAC) support
+
+CloudFront provides origin access control (OAC) for restricting access to a Lambda function URL origin.
+
+When you want to restrict access to a Lambda function URL origin by CloudFront, you can specify `Principal` as `cloudfront.amazonaws.com` and `SourceArn` as the ARN of the CloudFront distribution.
+
+See also [Restricting access to an AWS Lambda function URL origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html).
+
+```json
+{
+  "Config": {
+    "AuthType": "AWS_IAM",
+  },
+  "Permissions": [
+    {
+      "Principal": "cloudfront.amazonaws.com",
+      "SourceArn": "arn:aws:cloudfront::123456789012:distribution/XXXXXXXXX"
+    }
+  ]
+}
+```
 
 ## LICENSE
 

--- a/diff.go
+++ b/diff.go
@@ -208,8 +208,8 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 		removesB = append(removesB, b...)
 	}
 	if ds := diff.Diff(string(removesB), string(addsB)); ds != "" {
-		fmt.Println(color.RedString("---"))
-		fmt.Println(color.GreenString("+++"))
+		fmt.Println(color.RedString("--- permissions"))
+		fmt.Println(color.GreenString("+++ permissions"))
 		fmt.Print(coloredDiff(ds))
 	}
 

--- a/functionurl_test.go
+++ b/functionurl_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/go-test/deep"
 )
 
-var permissonsTestCases = []struct {
+var permissionsTestCases = []struct {
 	subject                string
 	statementJSON          []byte
 	expectedPrincipal      *string
 	expectedPrincipalOrgID *string
+	expectedSourceArn      *string
 }{
 	{
 		subject: "AuthType NONE",
@@ -69,19 +70,42 @@ var permissonsTestCases = []struct {
 		expectedPrincipal:      aws.String("123456789012"),
 		expectedPrincipalOrgID: nil,
 	},
+	{
+		subject: "AuthType AWS_IAM with Principal CF OAC",
+		statementJSON: []byte(`{
+			"Action": "lambda:InvokeFunctionUrl",
+			"Condition": {
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:cloudfront::123456789012:distribution/ABCDEFG12345678"
+				}
+			},
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "cloudfront.amazonaws.com"
+			},
+			"Resource": "arn:aws:lambda:ap-northeast-1:123456789012:function:hello",
+			"Sid": "lambroll-3b135eca4b14335775cda9f947966093a57d270f"
+		}`),
+		expectedPrincipal:      aws.String("cloudfront.amazonaws.com"),
+		expectedPrincipalOrgID: nil,
+		expectedSourceArn:      aws.String("arn:aws:cloudfront::123456789012:distribution/ABCDEFG12345678"),
+	},
 }
 
 func TestParseStatement(t *testing.T) {
-	for _, c := range permissonsTestCases {
+	for _, c := range permissionsTestCases {
 		st := &lambroll.PolicyStatement{}
 		if err := json.Unmarshal(c.statementJSON, st); err != nil {
 			t.Errorf("%s failed to unmarshal json: %s", c.subject, err)
 		}
-		if diff := deep.Equal(c.expectedPrincipal, st.PrincipalAccountID()); diff != nil {
-			t.Errorf("%s PrincipalAccountID diff %s", c.subject, diff)
+		if diff := deep.Equal(c.expectedPrincipal, st.PrincipalString()); diff != nil {
+			t.Errorf("%s PrincipalString diff %s", c.subject, diff)
 		}
 		if diff := deep.Equal(c.expectedPrincipalOrgID, st.PrincipalOrgID()); diff != nil {
 			t.Errorf("%s PrincipalOrgID diff %s", c.subject, diff)
+		}
+		if diff := deep.Equal(c.expectedSourceArn, st.SourceArn()); diff != nil {
+			t.Errorf("%s SourceArn diff %s", c.subject, diff)
 		}
 	}
 }


### PR DESCRIPTION
CloudFront OAC requires SourceArn support.

https://aws.amazon.com/jp/about-aws/whats-new/2024/04/amazon-cloudfront-oac-lambda-function-url-origins/
> Starting today, customers can protect their AWS Lambda URL origins by using CloudFront Origin Access Control (OAC) to only allow access from designated CloudFront distributions. 

#### CloudFront origin access control (OAC) support

CloudFront provides origin access control (OAC) for restricting access to a Lambda function URL origin.

When you want to restrict access to a Lambda function URL origin by CloudFront, you can specify `Principal` as `cloudfront.amazonaws.com` and `SourceArn` as the ARN of the CloudFront distribution.

See also [Restricting access to an AWS Lambda function URL origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html).

```json
{
  "Config": {
    "AuthType": "AWS_IAM",
  },
  "Permissions": [
    {
      "Principal": "cloudfront.amazonaws.com",
      "SourceArn": "arn:aws:cloudfront::123456789012:distribution/EXXXXXXXX"
    }
  ]
}
```

If you need to allow access from any CloudFront distributions in your account, you can specify `SourceArn` as `arn:aws:cloudfront::123456789012:distribution/*`.

