### PR TITLE
Fix: `--ignore .ImageConfig` didn't work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ Flags:
 
 lambroll also support to deploy a container image for Lambda.
 
-PackageType=Image and Code.ImageUri are required in function.json.
+`PackageType=Image` and `Code.ImageUri` are required in function.json.
+`ImageConfig` is optional.
 
 ```json
 {
@@ -253,6 +254,15 @@ PackageType=Image and Code.ImageUri are required in function.json.
   "PackageType": "Image",
   "Code": {
     "ImageUri": "012345678912.dkr.ecr.ap-northeast-1.amazonaws.com/lambda/test:latest"
+  },
+  "ImageConfig": {
+    "Command": [
+      "/path/to/bootstrap"
+    ],
+    "WorkingDirectory": "/var/task",
+    "EntryPoint": [
+      "/path/to/entrypoint"
+    ],
   }
 }
 ```

--- a/create.go
+++ b/create.go
@@ -65,7 +65,7 @@ func (app *App) prepareFunctionCodeForDeploy(ctx context.Context, opt *DeployOpt
 			log.Printf("[info] uploading function %d bytes to s3://%s/%s", info.Size(), *bucket, *key)
 			versionID, err := app.uploadFunctionToS3(ctx, zipfile, *bucket, *key)
 			if err != nil {
-				fmt.Errorf("failed to upload function zip to s3://%s/%s: %w", *bucket, *key, err)
+				return fmt.Errorf("failed to upload function zip to s3://%s/%s: %w", *bucket, *key, err)
 			}
 			if versionID != "" {
 				log.Printf("[info] object created as version %s", versionID)

--- a/deploy.go
+++ b/deploy.go
@@ -71,7 +71,7 @@ func (opt *DeployOption) String() string {
 	return string(b)
 }
 
-// Deploy deployes a new lambda function code
+// Deploy deploys a new lambda function code
 func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 	if err := opt.Expand(); err != nil {
 		return err

--- a/deploy.go
+++ b/deploy.go
@@ -119,6 +119,10 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 	}
 	fillDefaultValues(fn)
 
+	if err := app.prepareFunctionCodeForDeploy(ctx, opt, fn); err != nil {
+		return fmt.Errorf("failed to prepare function code for deploy: %w", err)
+	}
+
 	if ignore := opt.Ignore; ignore != "" {
 		q, err := gojq.Parse(ignore)
 		if err != nil {
@@ -133,10 +137,6 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 		src, _ := json.Marshal(fnAny)
 		fn = &Function{}
 		unmarshalJSON(src, &fn, app.functionFilePath)
-	}
-
-	if err := app.prepareFunctionCodeForDeploy(ctx, opt, fn); err != nil {
-		return fmt.Errorf("failed to prepare function code for deploy: %w", err)
 	}
 
 	log.Println("[info] updating function configuration", opt.label())
@@ -160,6 +160,7 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 		ImageConfig:       fn.ImageConfig,
 		SnapStart:         fn.SnapStart,
 	}
+	log.Printf("[debug] %s", jsonStr(confIn))
 
 	var newerVersion string
 	if !opt.DryRun {

--- a/utils.go
+++ b/utils.go
@@ -37,6 +37,14 @@ func toGeneralMap(s any, omitEmpty bool) (any, error) {
 	return x, nil
 }
 
+func jsonStr(s any) string {
+	b, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		log.Printf("[warn] failed to marshal json: %s", err)
+	}
+	return string(b)
+}
+
 func marshalJSON(s interface{}) ([]byte, error) {
 	x, err := toGeneralMap(s, true)
 	if err != nil {


### PR DESCRIPTION
`prepareFunctionCodeForDeploy()` may update an ImageConfig element.
So --ignore .ImageConfig didn't work.