### PR TITLE
chore: treat symlink as file when adding to zip

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -118,6 +118,20 @@ func matchExcludes(path string, excludes []string) bool {
 }
 
 func addToZip(z *zip.Writer, path, relpath string, info os.FileInfo) error {
+	// treat symlink as file
+	if info.Mode()&os.ModeSymlink != 0 {
+		linkTarget, err := os.Readlink(path)
+		if err != nil {
+			log.Printf("[error] failed to read symlink %s: %s", path, err)
+			return err
+		}
+		info, err = os.Stat(linkTarget)
+		if err != nil {
+			log.Printf("[error] failed to stat symlink target %s: %s", linkTarget, err)
+			return err
+		}
+		path = linkTarget
+	}
 	header, err := zip.FileInfoHeader(info)
 	if err != nil {
 		log.Println("[error] failed to create zip file header", err)


### PR DESCRIPTION
This commit modifies the `addToZip` function in `archive.go` to treat symlinks as files. If a file is a symlink, the function reads the symlink target and retrieves the file information for the target. This ensures that the correct file information is used when adding the file to the zip archive.

Refactor the code to handle symlinks and update the `path` variable accordingly before creating the zip file header.

This change improves the behavior of the `addToZip` function when dealing with symlinks, ensuring that the correct file information is used for symlinks in the zip archive.

This is useful when you have common files shared by multiple functions like below  but do not want to maintain it as layer.

```
.
├── common
│   └── hoge.py
├── lambda
│   ├── function.json
│   ├── hoge.py -> ../common/hoge.py
│   └── lambda_function.py
└── lambda2
    ├── function.json
    ├── hoge.py -> ../common/hoge.py
    └── lambda_function.py
```

Without this patch, zip archive is corrupt and cannot be properly decompressed. 

```
~/lambroll-symlink/lambda$ lambroll archive
2024/06/12 19:13:50 [info] lambroll v1.0.4
2024/06/12 19:13:50 [info] creating zip archive from .
2024/06/12 19:13:50 [info] zip archive wrote 1196 bytes
2024/06/12 19:13:50 [info] writing zip archive to function.zip
~/lambroll-symlink/lambda$ cd ..
~/lambroll-symlink$ unzip lambda/function.zip
Archive:  lambda/function.zip
  inflating: .python-version
  inflating: .vscode/launch.json
  inflating: hoge.py                 -> def hoge():^J    return "hoge"^J
  inflating: lambda_function.py
finishing deferred symbolic links:
  hoge.py                -> def hoge():^J    return "hoge"^J
```

but can be decompressed with this patch.

```
~/lambroll-symlink/lambda$ ~/bin/lambroll archive
2024/06/12 19:18:48 [info] lambroll
2024/06/12 19:18:48 [info] creating zip archive from .
2024/06/12 19:18:48 [info] zip archive wrote 1196 bytes
2024/06/12 19:18:48 [info] writing zip archive to function.zip
~/lambroll-symlink/lambda$ cd ..
~/lambroll-symlink$ unzip lambda/function.zip
Archive:  lambda/function.zip
  inflating: .python-version
  inflating: .vscode/launch.json
  inflating: hoge.py
  inflating: lambda_function.py
```