### PR TITLE
fix: default LoggingConfig

### DIFF
--- a/lambroll.go
+++ b/lambroll.go
@@ -336,10 +336,8 @@ func fillDefaultValues(fn *Function) {
 	}
 	if lc := fn.LoggingConfig; lc == nil {
 		fn.LoggingConfig = &types.LoggingConfig{
-			LogFormat:           types.LogFormatText,
-			LogGroup:            aws.String(resolveLogGroup(fn)),
-			ApplicationLogLevel: types.ApplicationLogLevelInfo,
-			SystemLogLevel:      types.SystemLogLevelInfo,
+			LogFormat: types.LogFormatText,
+			LogGroup:  aws.String(resolveLogGroup(fn)),
 		}
 	} else {
 		if lc.LogFormat == "" {
@@ -348,10 +346,10 @@ func fillDefaultValues(fn *Function) {
 		if lc.LogGroup == nil {
 			lc.LogGroup = aws.String(resolveLogGroup(fn))
 		}
-		if lc.ApplicationLogLevel == "" {
+		if lc.ApplicationLogLevel == "" && lc.LogFormat == types.LogFormatJson {
 			lc.ApplicationLogLevel = types.ApplicationLogLevelInfo
 		}
-		if lc.SystemLogLevel == "" {
+		if lc.SystemLogLevel == "" && lc.LogFormat == types.LogFormatJson {
 			lc.SystemLogLevel = types.SystemLogLevelInfo
 		}
 	}

--- a/lambroll_test.go
+++ b/lambroll_test.go
@@ -26,10 +26,8 @@ var testCasesFillDefaultValues = []struct {
 			},
 			Layers: []string{},
 			LoggingConfig: &types.LoggingConfig{
-				ApplicationLogLevel: "INFO",
-				LogFormat:           types.LogFormatText,
-				LogGroup:            aws.String("/aws/lambda/test"),
-				SystemLogLevel:      "INFO",
+				LogFormat: types.LogFormatText,
+				LogGroup:  aws.String("/aws/lambda/test"),
 			},
 			MemorySize: aws.Int32(128),
 			SnapStart: &types.SnapStart{


### PR DESCRIPTION
ApplicationLogLevel and SystemLogLevel are supported for JSON format only.
fixes #405.