### PR TITLE
remove type alias

### DIFF
--- a/create.go
+++ b/create.go
@@ -136,8 +136,9 @@ func (app *App) create(ctx context.Context, opt *DeployOption, fn *Function) err
 	return nil
 }
 
-func (app *App) createFunction(ctx context.Context, fn *lambda.CreateFunctionInput) (*lambda.CreateFunctionOutput, error) {
-	if res, err := app.lambda.CreateFunction(ctx, fn); err != nil {
+func (app *App) createFunction(ctx context.Context, fn *Function) (*lambda.CreateFunctionOutput, error) {
+	in := lambda.CreateFunctionInput(*fn)
+	if res, err := app.lambda.CreateFunction(ctx, &in); err != nil {
 		return nil, fmt.Errorf("failed to create function: %w", err)
 	} else {
 		return res, app.waitForLastUpdateStatusSuccessful(ctx, *fn.FunctionName)

--- a/lambroll.go
+++ b/lambroll.go
@@ -38,7 +38,7 @@ var retryPolicy = retry.Policy{
 
 // Function represents configuration of Lambda function
 // type Function = lambda.CreateFunctionInput
-type Function = lambda.CreateFunctionInput
+type Function lambda.CreateFunctionInput
 
 // Tags represents tags of function
 type Tags map[string]string
@@ -414,7 +414,7 @@ func exportEnvFile(file string) error {
 
 var errCannotUpdateImageAndZip = fmt.Errorf("cannot update function code between Image and Zip")
 
-func validateUpdateFunction(currentConf *types.FunctionConfiguration, currentCode *types.FunctionCodeLocation, newFn *lambda.CreateFunctionInput) error {
+func validateUpdateFunction(currentConf *types.FunctionConfiguration, currentCode *types.FunctionCodeLocation, newFn *Function) error {
 	if currentConf == nil {
 		// create new function
 		return nil


### PR DESCRIPTION
Remove type alias. 
Define type `Function` as `lambda.CreateFunctionInput`.