### PR TITLE
Add --option flag to read default options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,21 +216,21 @@ If the option file is found in the current directory, lambroll reads the file an
 
 ```jsonnet
 {
-  logLevel: 'info',
+  log_level: 'info',
   color: true,
   region: 'ap-northeast-1',
   profile: 'default',
   tfstate: 's3://my-bucket/terraform.tfstate',
-  prefixedTfstate: {
+  prefixed_tfstate: {
     my_first_: 's3://my-bucket/first.tfstate',
     my_second_: 's3://my-bucket/second.tfstate',
   },
   endpoint: 'http://localhost:9001',
   envfile: ['.env1', '.env2'],
-  extStr: {
+  ext_str: {
     accountID: '0123456789012',
   },
-  extCode: {
+  ext_code: {
     memorySize: '128 * 4',
   },
 }

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ See the above usage for the environment variable names.
 
 `lambroll.json` or `lambroll.jsonnet` can be used as an option file.
 
-If the option file is found in the current directory, lambroll reads the file and applies the options.
+If the option file is found in the current directory, lambroll reads the file and applies to the default values of global flags.
 
 ```jsonnet
 {
@@ -237,7 +237,8 @@ If the option file is found in the current directory, lambroll reads the file an
 ```
 
 All fields are optional. If the field is not defined, the default value is used.
-When passed by command line options, the command line option takes precedence over the option file.
+
+When command-line flags are specified, they take precedence over the options file.
 
 ### Init
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,49 @@ Commands:
 Run "lambroll <command> --help" for more information on a command.
 ```
 
+### Global flags
+
+lambroll has global flags for all commands.
+
+These flags can be set by environment variables or option file (`lambroll.json` or `lambroll.jsonnet`).
+
+#### Environment variables
+
+For example, `--log-level=debug` can be set by `LAMBROLL_LOGLEVEL=debug`.
+
+See the above usage for the environment variable names.
+
+#### Option file
+
+`lambroll.json` or `lambroll.jsonnet` can be used as an option file.
+
+If the option file is found in the current directory, lambroll reads the file and applies the options.
+
+```jsonnet
+{
+  logLevel: 'info',
+  color: true,
+  region: 'ap-northeast-1',
+  profile: 'default',
+  tfstate: 's3://my-bucket/terraform.tfstate',
+  prefixedTfstate: {
+    my_first_: 's3://my-bucket/first.tfstate',
+    my_second_: 's3://my-bucket/second.tfstate',
+  },
+  endpoint: 'http://localhost:9001',
+  envfile: ['.env1', '.env2'],
+  extStr: {
+    accountID: '0123456789012',
+  },
+  extCode: {
+    memorySize: '128 * 4',
+  },
+}
+```
+
+All fields are optional. If the field is not defined, the default value is used.
+When passed by command line options, the command line option takes precedence over the option file.
+
 ### Init
 
 `lambroll init` initialize function.json by existing function.

--- a/README.md
+++ b/README.md
@@ -237,8 +237,9 @@ If the option file is found in the current directory, lambroll reads the file an
 ```
 
 All fields are optional. If the field is not defined, the default value is used.
-
 When command-line flags are specified, they take precedence over the options file.
+
+While parsing the option file, lambroll evaluates only the `{{env}}` and `{{must_env}}` template functions and `env` and `must_env` native functions in Jsonnet. Other functions are not available.
 
 ### Init
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ $ lambroll deploy
 ## Usage
 
 ```console
-Usage: lambroll <command>
+Usage: lambroll <command> [flags]
 
 Flags:
   -h, --help                              Show context-sensitive help.
+      --config=STRING                     config file path ($LAMBROLL_CONFIG)
       --function=STRING                   Function file path ($LAMBROLL_FUNCTION)
       --log-level="info"                  log level (trace, debug, info, warn, error) ($LAMBROLL_LOGLEVEL)
       --[no-]color                        enable colored output ($LAMBROLL_COLOR)
@@ -200,7 +201,7 @@ Run "lambroll <command> --help" for more information on a command.
 
 lambroll has global flags for all commands.
 
-These flags can be set by environment variables or option file (`lambroll.json` or `lambroll.jsonnet`).
+These flags can be set by environment variables or option file (`--config` or `lambroll.json` or `lambroll.jsonnet`).
 
 #### Environment variables
 
@@ -210,7 +211,7 @@ See the above usage for the environment variable names.
 
 #### Option file
 
-`lambroll.json` or `lambroll.jsonnet` can be used as an option file.
+`--config=filename` or `lambroll.json` or `lambroll.jsonnet` can be used as an option file.
 
 If the option file is found in the current directory, lambroll reads the file and applies to the default values of global flags.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Usage: lambroll <command> [flags]
 
 Flags:
   -h, --help                              Show context-sensitive help.
-      --config=STRING                     config file path ($LAMBROLL_CONFIG)
+      --option=STRING                     option file path ($LAMBROLL_OPTION)
       --function=STRING                   Function file path ($LAMBROLL_FUNCTION)
       --log-level="info"                  log level (trace, debug, info, warn, error) ($LAMBROLL_LOGLEVEL)
       --[no-]color                        enable colored output ($LAMBROLL_COLOR)
@@ -201,7 +201,7 @@ Run "lambroll <command> --help" for more information on a command.
 
 lambroll has global flags for all commands.
 
-These flags can be set by environment variables or option file (`--config` or `lambroll.json` or `lambroll.jsonnet`).
+These flags can be set by environment variables or option file (`--option`).
 
 #### Environment variables
 
@@ -211,9 +211,9 @@ See the above usage for the environment variable names.
 
 #### Option file
 
-`--config=filename` or `lambroll.json` or `lambroll.jsonnet` can be used as an option file.
+`--option=filename` can be used as an option file.
 
-If the option file is found in the current directory, lambroll reads the file and applies to the default values of global flags.
+If the option file is specified, lambroll reads the file and applies to the default values of global flags.
 
 ```jsonnet
 {

--- a/README.md
+++ b/README.md
@@ -215,7 +215,10 @@ See the above usage for the environment variable names.
 
 If the option file is specified, lambroll reads the file and applies to the default values of global flags.
 
+The file format is JSON or Jsonnet.
+
 ```jsonnet
+// option.jsonnet
 {
   log_level: 'info',
   color: true,

--- a/cli.go
+++ b/cli.go
@@ -85,7 +85,7 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 
 	// load default options
 	if optionFilePath != "" {
-		defaultOpt, err := loadDefinitionFile[Option](nil, optionFilePath, DefaultOptionFilenames)
+		defaultOpt, err := loadDefinitionFile[Option](nil, optionFilePath, nil)
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("failed to load option file: %w", err)
 		}

--- a/cli.go
+++ b/cli.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -13,12 +12,14 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/fatih/color"
 	"github.com/fujiwara/logutils"
+	"github.com/samber/lo"
 )
 
 type Option struct {
-	Function string `help:"Function file path" env:"LAMBROLL_FUNCTION" json:"function,omitempty"`
-	LogLevel string `help:"log level (trace, debug, info, warn, error)" default:"info" enum:",trace,debug,info,warn,error" env:"LAMBROLL_LOGLEVEL" json:"log_level"`
-	Color    bool   `help:"enable colored output" default:"true" env:"LAMBROLL_COLOR" negatable:"" json:"color,omitempty"`
+	ConfigFilePath string `help:"config file path" env:"LAMBROLL_CONFIG" name:"config" json:"-"`
+	Function       string `help:"Function file path" env:"LAMBROLL_FUNCTION" json:"function,omitempty"`
+	LogLevel       string `help:"log level (trace, debug, info, warn, error)" default:"info" enum:",trace,debug,info,warn,error" env:"LAMBROLL_LOGLEVEL" json:"log_level"`
+	Color          bool   `help:"enable colored output" default:"true" env:"LAMBROLL_COLOR" negatable:"" json:"color,omitempty"`
 
 	Region          *string           `help:"AWS region" env:"AWS_REGION" json:"region,omitempty"`
 	Profile         *string           `help:"AWS credential profile name" env:"AWS_PROFILE" json:"profile,omitempty"`
@@ -51,22 +52,21 @@ type CLIOptions struct {
 
 type CLIParseFunc func([]string) (string, *CLIOptions, func(), error)
 
-// parse just the envfile opts to load envfile
-func prepareEnvFromArgs(args []string) error {
+func prepareCLI(args []string) (string, []string, error) {
 	var opts CLIOptions
 	p, err := kong.New(&opts)
 	if err != nil {
-		return fmt.Errorf("failed to new kong: %w", err)
+		return "", nil, fmt.Errorf("failed to new kong: %w", err)
 	}
 	if _, err := p.Parse(args); err != nil {
-		return fmt.Errorf("failed to parse args: %w", err)
+		return "", nil, fmt.Errorf("failed to parse args: %w", err)
 	}
 	for _, envfile := range opts.Envfile {
 		if err := exportEnvFile(envfile); err != nil {
-			return fmt.Errorf("failed to load envfile: %w", err)
+			return "", nil, fmt.Errorf("failed to load envfile: %w", err)
 		}
 	}
-	return nil
+	return opts.ConfigFilePath, opts.Envfile, nil
 }
 
 func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
@@ -76,21 +76,19 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 	}
 
 	// resolve envfile from args at first
-	if err := prepareEnvFromArgs(args); err != nil {
+	optionFilePath, argEnvfiles, err := prepareCLI(args)
+	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to prepare env from args: %w", err)
 	}
-
+	var envfiles []string
 	kongOpts := []kong.Option{kong.Vars{"version": Version}}
 
-	// load default options from lambroll.json or .jsonnet
-	defaultOpt, err := loadDefinitionFile[Option](nil, "", DefaultOptionFilenames)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// ignore not found error
-		} else {
-			return "", nil, nil, fmt.Errorf("failed to load default options: %w", err)
+	// load default options
+	if optionFilePath != "" {
+		defaultOpt, err := loadDefinitionFile[Option](nil, optionFilePath, DefaultOptionFilenames)
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("failed to load config file: %w", err)
 		}
-	} else {
 		defaultOptBytes, err := json.Marshal(defaultOpt)
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("failed to marshal default options: %w", err)
@@ -100,6 +98,10 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 			return "", nil, nil, fmt.Errorf("failed to parse default options: %w", err)
 		}
 		kongOpts = append(kongOpts, kong.Resolvers(resolver))
+		envfiles = defaultOpt.Envfile
+		envfiles = append(envfiles, argEnvfiles...)
+	} else {
+		envfiles = argEnvfiles
 	}
 
 	var opts CLIOptions
@@ -111,6 +113,7 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to parse args: %w", err)
 	}
+	opts.Envfile = lo.Uniq(envfiles) // envfiles are parsed before, so it's safe to overwrite
 
 	sub := strings.Fields(c.Command())[0]
 	return sub, &opts, func() { c.PrintUsage(true) }, nil

--- a/cli.go
+++ b/cli.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Option struct {
-	ConfigFilePath string `help:"config file path" env:"LAMBROLL_CONFIG" name:"config" json:"-"`
+	OptionFilePath string `help:"option file path" env:"LAMBROLL_OPTION" name:"option" json:"-"`
 	Function       string `help:"Function file path" env:"LAMBROLL_FUNCTION" json:"function,omitempty"`
 	LogLevel       string `help:"log level (trace, debug, info, warn, error)" default:"info" enum:",trace,debug,info,warn,error" env:"LAMBROLL_LOGLEVEL" json:"log_level"`
 	Color          bool   `help:"enable colored output" default:"true" env:"LAMBROLL_COLOR" negatable:"" json:"color,omitempty"`
@@ -66,7 +66,7 @@ func prepareCLI(args []string) (string, []string, error) {
 			return "", nil, fmt.Errorf("failed to load envfile: %w", err)
 		}
 	}
-	return opts.ConfigFilePath, opts.Envfile, nil
+	return opts.OptionFilePath, opts.Envfile, nil
 }
 
 func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
@@ -87,7 +87,7 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 	if optionFilePath != "" {
 		defaultOpt, err := loadDefinitionFile[Option](nil, optionFilePath, DefaultOptionFilenames)
 		if err != nil {
-			return "", nil, nil, fmt.Errorf("failed to load config file: %w", err)
+			return "", nil, nil, fmt.Errorf("failed to load option file: %w", err)
 		}
 		defaultOptBytes, err := json.Marshal(defaultOpt)
 		if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -51,29 +51,36 @@ type CLIOptions struct {
 
 type CLIParseFunc func([]string) (string, *CLIOptions, func(), error)
 
+// parse just the envfile opts to load envfile
+func prepareEnvFromArgs(args []string) error {
+	var opts CLIOptions
+	p, err := kong.New(&opts)
+	if err != nil {
+		return fmt.Errorf("failed to new kong: %w", err)
+	}
+	if _, err := p.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse args: %w", err)
+	}
+	for _, envfile := range opts.Envfile {
+		if err := exportEnvFile(envfile); err != nil {
+			return fmt.Errorf("failed to load envfile: %w", err)
+		}
+	}
+	return nil
+}
+
 func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 	// compatible with v1
 	if len(args) == 0 || len(args) > 0 && args[0] == "help" {
 		args = []string{"--help"}
 	}
 
-	kongOpts := []kong.Option{kong.Vars{"version": Version}}
+	// resolve envfile from args at first
+	if err := prepareEnvFromArgs(args); err != nil {
+		return "", nil, nil, fmt.Errorf("failed to prepare env from args: %w", err)
+	}
 
-	// parse just the envfile opts to load envfile
-	var opts CLIOptions
-	p, err := kong.New(&opts, kongOpts...)
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to new kong: %w", err)
-	}
-	if _, err := p.Parse(args); err != nil {
-		return "", nil, nil, fmt.Errorf("failed to parse args: %w", err)
-	}
-	for _, envfile := range opts.Envfile {
-		if err := exportEnvFile(envfile); err != nil {
-			return "", nil, nil, fmt.Errorf("failed to load envfile: %w", err)
-		}
-	}
-	mergedEnvfiles := make([]string, 0)
+	kongOpts := []kong.Option{kong.Vars{"version": Version}}
 
 	// load default options from lambroll.json or .jsonnet
 	defaultOpt, err := loadDefinitionFile[Option](nil, "", DefaultOptionFilenames)
@@ -92,10 +99,10 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("failed to parse default options: %w", err)
 		}
-		mergedEnvfiles = append(mergedEnvfiles, defaultOpt.Envfile...)
 		kongOpts = append(kongOpts, kong.Resolvers(resolver))
 	}
 
+	var opts CLIOptions
 	parser, err := kong.New(&opts, kongOpts...)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to new kong: %w", err)
@@ -104,7 +111,7 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to parse args: %w", err)
 	}
-	opts.Envfile = append(mergedEnvfiles, opts.Envfile...)
+
 	sub := strings.Fields(c.Command())[0]
 	return sub, &opts, func() { c.PrintUsage(true) }, nil
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -27,12 +27,12 @@ var cliTests = []struct {
 		},
 	},
 	{
-		args: []string{"render", "--config", "debug.jsonnet"},
+		args: []string{"render", "--option", "debug.jsonnet"},
 		sub:  "render",
 		option: &lambroll.Option{
 			LogLevel:       "debug",
 			Color:          true,
-			ConfigFilePath: "debug.jsonnet",
+			OptionFilePath: "debug.jsonnet",
 			Envfile:        []string{},
 		},
 	},
@@ -48,14 +48,14 @@ var cliTests = []struct {
 	{
 		args: []string{
 			"--envfile=envfile.local",
-			"--config", "global.jsonnet",
+			"--option", "global.jsonnet",
 			"--function", "function.jsonnet",
 			"render",
 		},
 		sub: "render",
 		option: &lambroll.Option{
 			Function:       "function.jsonnet",
-			ConfigFilePath: "global.jsonnet",
+			OptionFilePath: "global.jsonnet",
 			Color:          true,
 			Envfile:        []string{"envfile.global", "envfile.local"},
 		},
@@ -86,35 +86,35 @@ var cliTests = []struct {
 		},
 	},
 	{
-		args: []string{"render", "--config", "useenv.jsonnet", "--envfile=envfile.useenv"},
+		args: []string{"render", "--option", "useenv.jsonnet", "--envfile=envfile.useenv"},
 		sub:  "render",
 		option: &lambroll.Option{
-			ConfigFilePath: "useenv.jsonnet",
+			OptionFilePath: "useenv.jsonnet",
 			Function:       "hello",
 			Color:          true,
 			Envfile:        []string{"envfile.useenv"},
 		},
 	},
 	{
-		args: []string{"render", "--config", "useenv.jsonnet"},
+		args: []string{"render", "--option", "useenv.jsonnet"},
 		sub:  "render",
 		env: map[string]string{
 			"TEST_FUNCTION_NAME": "world",
 		},
 		option: &lambroll.Option{
-			ConfigFilePath: "useenv.jsonnet",
+			OptionFilePath: "useenv.jsonnet",
 			Function:       "world",
 			Color:          true,
 			Envfile:        []string{},
 		},
 	},
 	{
-		args: []string{"render", "--config", "missing.jsonnet"},
+		args: []string{"render", "--option", "missing.jsonnet"},
 		sub:  "render",
 		err:  os.ErrNotExist,
 	},
 	{
-		args: []string{"render", "--config", "missing.json"},
+		args: []string{"render", "--option", "missing.json"},
 		sub:  "render",
 		err:  os.ErrNotExist,
 	},
@@ -128,9 +128,9 @@ func TestParseCLI(t *testing.T) {
 	for _, tt := range cliTests {
 		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
 			for k, v := range tt.env {
-				reset := setenv(k, v)
-				defer reset()
+				lambroll.Setenv(k, v)
 			}
+			defer lambroll.ResetEnv()
 			sub, opt, _, err := lambroll.ParseCLI(tt.args)
 			if err != nil {
 				if tt.err == nil {
@@ -152,17 +152,5 @@ func TestParseCLI(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func setenv(key, value string) func() {
-	orig, found := os.LookupEnv(key)
-	os.Setenv(key, value)
-	return func() {
-		if found {
-			os.Setenv(key, orig)
-		} else {
-			os.Unsetenv(key)
-		}
 	}
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,168 @@
+package lambroll_test
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fujiwara/lambroll"
+	"github.com/google/go-cmp/cmp"
+)
+
+var cliTests = []struct {
+	args   []string
+	env    map[string]string
+	sub    string
+	option *lambroll.Option
+	err    error
+}{
+	{
+		args: []string{"render"},
+		sub:  "render",
+		option: &lambroll.Option{
+			LogLevel: "info",
+			Color:    true,
+			Envfile:  []string{},
+		},
+	},
+	{
+		args: []string{"render", "--config", "debug.jsonnet"},
+		sub:  "render",
+		option: &lambroll.Option{
+			LogLevel:       "debug",
+			Color:          true,
+			ConfigFilePath: "debug.jsonnet",
+			Envfile:        []string{},
+		},
+	},
+	{
+		args: []string{"render", "--envfile=envfile.global"},
+		sub:  "render",
+		option: &lambroll.Option{
+			LogLevel: "info",
+			Color:    true,
+			Envfile:  []string{"envfile.global"},
+		},
+	},
+	{
+		args: []string{
+			"--envfile=envfile.local",
+			"--config", "global.jsonnet",
+			"--function", "function.jsonnet",
+			"render",
+		},
+		sub: "render",
+		option: &lambroll.Option{
+			Function:       "function.jsonnet",
+			ConfigFilePath: "global.jsonnet",
+			Color:          true,
+			Envfile:        []string{"envfile.global", "envfile.local"},
+		},
+	},
+	{
+		args: []string{
+			"--envfile=envfile.global", "--envfile=envfile.local",
+			"render",
+		},
+		sub: "render",
+		option: &lambroll.Option{
+			LogLevel: "info",
+			Color:    true,
+			Envfile:  []string{"envfile.global", "envfile.local"},
+		},
+	},
+	{
+		args: []string{"render"},
+		sub:  "render",
+		env: map[string]string{
+			"LAMBROLL_LOGLEVEL": "error",
+			"LAMBROLL_COLOR":    "false",
+		},
+		option: &lambroll.Option{
+			LogLevel: "error",
+			Color:    false,
+			Envfile:  []string{},
+		},
+	},
+	{
+		args: []string{"render", "--config", "useenv.jsonnet", "--envfile=envfile.useenv"},
+		sub:  "render",
+		option: &lambroll.Option{
+			ConfigFilePath: "useenv.jsonnet",
+			Function:       "hello",
+			Color:          true,
+			Envfile:        []string{"envfile.useenv"},
+		},
+	},
+	{
+		args: []string{"render", "--config", "useenv.jsonnet"},
+		sub:  "render",
+		env: map[string]string{
+			"TEST_FUNCTION_NAME": "world",
+		},
+		option: &lambroll.Option{
+			ConfigFilePath: "useenv.jsonnet",
+			Function:       "world",
+			Color:          true,
+			Envfile:        []string{},
+		},
+	},
+	{
+		args: []string{"render", "--config", "missing.jsonnet"},
+		sub:  "render",
+		err:  os.ErrNotExist,
+	},
+	{
+		args: []string{"render", "--config", "missing.json"},
+		sub:  "render",
+		err:  os.ErrNotExist,
+	},
+}
+
+func TestParseCLI(t *testing.T) {
+	cwd, _ := os.Getwd()
+	os.Chdir("test/cli")
+	defer os.Chdir(cwd)
+
+	for _, tt := range cliTests {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
+			for k, v := range tt.env {
+				reset := setenv(k, v)
+				defer reset()
+			}
+			sub, opt, _, err := lambroll.ParseCLI(tt.args)
+			if err != nil {
+				if tt.err == nil {
+					t.Errorf("error is expected, but got nil. got %v", err)
+				} else if errors.Is(err, tt.err) {
+					// OK
+				} else {
+					// unexpected, but OK
+					t.Logf("expected %v, got %v", tt.err, err)
+				}
+				return
+			}
+			if sub != tt.sub {
+				t.Errorf("unexpected subcommand: expected %s, got %s", tt.sub, sub)
+			}
+			if tt.option != nil {
+				if diff := cmp.Diff(*tt.option, opt.Option); diff != "" {
+					t.Errorf("unexpected option: diff %s", diff)
+				}
+			}
+		})
+	}
+}
+
+func setenv(key, value string) func() {
+	orig, found := os.LookupEnv(key)
+	os.Setenv(key, value)
+	return func() {
+		if found {
+			os.Setenv(key, orig)
+		} else {
+			os.Unsetenv(key)
+		}
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,10 @@
 package lambroll
 
+import (
+	"os"
+	"sync"
+)
+
 var (
 	CreateZipArchive  = createZipArchive
 	ExpandExcludeFile = expandExcludeFile
@@ -21,4 +26,29 @@ func (app *App) CallerIdentity() *CallerIdentity {
 
 func (app *App) LoadFunction(f string) (*Function, error) {
 	return app.loadFunction(f)
+}
+
+func init() {
+	Setenv = tSetenv
+}
+
+var envs = sync.Map{}
+
+func tSetenv(key, value string) error {
+	orig, ok := os.LookupEnv(key)
+	os.Setenv(key, value)
+	if ok {
+		envs.Store(key, func() { os.Setenv(key, orig) })
+	} else {
+		envs.Store(key, func() { os.Unsetenv(key) })
+	}
+	return nil
+}
+
+func ResetEnv() {
+	envs.Range(func(key, value interface{}) bool {
+		value.(func())()
+		return true
+	})
+	envs = sync.Map{}
 }

--- a/jsonnet_test.go
+++ b/jsonnet_test.go
@@ -28,6 +28,7 @@ var testCaseJsonnetNativeFuncs = []struct {
 		name: "env FOO not set",
 		env: map[string]string{
 			"BAR": "bar",
+			"FOO": "",
 		},
 		expected: map[string]string{
 			"foo": "default",
@@ -63,8 +64,9 @@ func TestJsonnetNativeFuncs(t *testing.T) {
 	for _, c := range testCaseJsonnetNativeFuncs {
 		t.Run(c.name, func(t *testing.T) {
 			for k, v := range c.env {
-				t.Setenv(k, v)
+				lambroll.Setenv(k, v)
 			}
+			defer lambroll.ResetEnv()
 			out, err := vm.EvaluateAnonymousSnippet("test.jsonnet", testSrcJsonnet)
 			if c.errExpected {
 				if err == nil {

--- a/lambroll.go
+++ b/lambroll.go
@@ -425,6 +425,8 @@ func newSnapStart(s *types.SnapStartResponse) *types.SnapStart {
 	}
 }
 
+var Setenv = os.Setenv
+
 func exportEnvFile(file string) error {
 	if file == "" {
 		return nil
@@ -441,7 +443,7 @@ func exportEnvFile(file string) error {
 		return err
 	}
 	for key, value := range envs {
-		os.Setenv(key, value)
+		Setenv(key, value)
 	}
 	return nil
 }

--- a/lambroll.go
+++ b/lambroll.go
@@ -72,12 +72,6 @@ var (
 		"function_url.jsonnet",
 	}
 
-	// DefaultOptionFilenames defines file name for option definition.
-	DefaultOptionFilenames = []string{
-		"lambroll.json",
-		"lambroll.jsonnet",
-	}
-
 	// FunctionZipFilename defines file name for zip archive downloaded at init.
 	FunctionZipFilename = "function.zip"
 
@@ -88,8 +82,6 @@ var (
 		DefaultFunctionFilenames[1],
 		DefaultFunctionURLFilenames[0],
 		DefaultFunctionURLFilenames[1],
-		DefaultOptionFilenames[0],
-		DefaultOptionFilenames[1],
 		FunctionZipFilename,
 		".git/*",
 		".terraform/*",

--- a/test/cli/debug.jsonnet
+++ b/test/cli/debug.jsonnet
@@ -1,0 +1,3 @@
+{
+    log_level: "debug",
+}

--- a/test/cli/envfile.global
+++ b/test/cli/envfile.global
@@ -1,0 +1,1 @@
+FOO=global

--- a/test/cli/envfile.local
+++ b/test/cli/envfile.local
@@ -1,0 +1,1 @@
+FOO=local

--- a/test/cli/envfile.useenv
+++ b/test/cli/envfile.useenv
@@ -1,0 +1,1 @@
+TEST_FUNCTION_NAME="hello"

--- a/test/cli/global.jsonnet
+++ b/test/cli/global.jsonnet
@@ -1,0 +1,3 @@
+{
+    envfile: ["envfile.global"],
+}

--- a/test/cli/useenv.jsonnet
+++ b/test/cli/useenv.jsonnet
@@ -1,0 +1,4 @@
+local must_env = std.native("must_env");
+{
+    "function": must_env("TEST_FUNCTION_NAME"),
+}

--- a/utils.go
+++ b/utils.go
@@ -99,7 +99,7 @@ func findDefinitionFile(preferred string, defaults []string) (string, error) {
 			return name, nil
 		}
 	}
-	return "", fmt.Errorf("function file (%s) not found", strings.Join(DefaultFunctionFilenames, " or "))
+	return "", fmt.Errorf("file (%s) not found: %w", strings.Join(DefaultFunctionFilenames, " or "), os.ErrNotExist)
 }
 
 func jsonToJsonnet(src []byte, filepath string) ([]byte, error) {


### PR DESCRIPTION
refs https://github.com/fujiwara/lambroll/issues/449

#### Option file

`--option=filename` can be used as an option file.

If the option file is found in the current directory, lambroll reads the file and applies to the default values of global flags.

The file format is JSON or Jsonnet.

```jsonnet
{
  log_level: 'info',
  color: true,
  region: 'ap-northeast-1',
  profile: 'default',
  tfstate: 's3://my-bucket/terraform.tfstate',
  prefixed_tfstate: {
    my_first_: 's3://my-bucket/first.tfstate',
    my_second_: 's3://my-bucket/second.tfstate',
  },
  endpoint: 'http://localhost:9001',
  envfile: ['.env1', '.env2'],
  ext_str: {
    accountID: '0123456789012',
  },
  ext_code: {
    memorySize: '128 * 4',
  },
}
```

All fields are optional. If the field is not defined, the default value is used.
When command-line flags are specified, they take precedence over the options file.

While parsing the option file, lambroll evaluates only the `{{env}}` and `{{must_env}}` template functions and `env` and `must_env` native functions in Jsonnet. Other functions are not available.
