### PR TITLE
feat: Add lambroll version file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ jobs:
       - uses: fujiwara/lambroll@v1
         with:
           version: v1.1.0
+          # version-file: .lambroll-version
       - run: |
           lambroll deploy
 ```
@@ -89,6 +90,7 @@ jobs:
 Note:
 - `version` is not required, but it is recommended that the version be specified.
   - The default version is not fixed and may change in the future.
+- `version-file` can also be used to specify lambroll version by using the file that contains lambroll version (e.g. 1.1.0).
 - `os` and `arch` are automatically detected. (Some previous versions use `os` and `arch` as inputs, but they are deprecated.)
 
 ## Quick start

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,22 @@ inputs:
   version:
     description: "A version to install lambroll"
     default: "v1.0.5"
+    required: false
+  version-file:
+    description: "File name that contains the lambroll version."
+    required: false
 runs:
   using: "composite"
   steps:
+    - name: Set lambroll version
+      id: set-lambroll-version
+      run: |
+        VERSION=${{ inputs.version }}
+        if [ -n "${{ inputs.version-file }}" ]; then
+          VERSION=v$(cat ${{ inputs.version-file }})
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      shell: bash
     - name: Set file name
       id: set-filename
       run: |
@@ -20,12 +33,12 @@ runs:
           *) BIN_ARCH="amd64" ;;
         esac
 
-        FILENAME=lambroll_${{ inputs.version }}_${BIN_OS}_${BIN_ARCH}.tar.gz
+        FILENAME=lambroll_${{ steps.set-lambroll-version.outputs.VERSION }}_${BIN_OS}_${BIN_ARCH}.tar.gz
         echo "FILENAME=$FILENAME" >> $GITHUB_OUTPUT
       shell: bash
     - run: |
-        mkdir -p /tmp/lambroll-${{ inputs.version }}
-        cd /tmp/lambroll-${{ inputs.version }}
-        curl -sL https://github.com/fujiwara/lambroll/releases/download/${{ inputs.version }}/${{ steps.set-filename.outputs.FILENAME }} | tar zxvf -
+        mkdir -p /tmp/lambroll-${{ steps.set-lambroll-version.outputs.VERSION }}
+        cd /tmp/lambroll-${{ steps.set-lambroll-version.outputs.VERSION }}
+        curl -sL https://github.com/fujiwara/lambroll/releases/download/${{ steps.set-lambroll-version.outputs.VERSION }}/${{ steps.set-filename.outputs.FILENAME }} | tar zxvf -
         sudo install lambroll /usr/local/bin
       shell: bash


### PR DESCRIPTION
Add input (version-file) to GitHub's Composite Action to specify lambroll version. 
By using version file, we can fix lambroll version, and we can manage version by changing this file. 

```yaml
- uses: fujiwara/lambroll@v1
  with:
    version-file: .lambroll-version
```

It is also possible to update lambroll version automatically by using Renovate as follows.

```json
{
  "customManagers": [
    {
      "customType": "regex",
      "fileMatch": ["^\\.lambroll-version$"],
      "matchStrings": ["(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
      "datasourceTemplate": "github-releases",
      "depNameTemplate": "fujiwara/lambroll",
      "extractVersionTemplate": "^v(?<version>.*)$",
    },
  ],
}
```

It can be defined as follows, but it seems to be a bit redundant and difficult to manage when used in multiple workflows.

```yaml
- run: |
    echo "LAMBROLL_VERSION=v$(cat .lambroll-version)" >> "$GITHUB_ENV"
- uses: fujiwara/lambroll@v1
  with:
    version: ${{ env.LAMBROLL_VERSION }}
```

I am new to OSS Contribution, so please let me know if I am making any mistakes.