### PR TITLE
Release for v1.0.4

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -27,7 +27,7 @@ jobs:
       - run: |
           lambroll version 2>&1 | fgrep v1.0.5
       - run: |
-          echo 1.1.3 > .test-lambroll-version
+          echo 1.1.4 > .test-lambroll-version
       - uses: fujiwara/lambroll@v1-actions-test
         with:
           version-file: .test-lambroll-version

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,48 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.template (Optional)
+#       Pull request template file in go template format
+#
+#   tagpr.templateText (Optional)
+#       Pull request template text in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+#
+#   tagpr.majorLabels (Optional)
+#       Label of major update targets. Default is [major]
+#
+#   tagpr.minorLabels (Optional)
+#       Label of minor update targets. Default is [minor]
+#
+#   tagpr.commitPrefix (Optional)
+#       Prefix of commit message. Default is "[tagpr]"
+#
+[tagpr]
+	vPrefix = true
+	releaseBranch = v1
+	versionFile = .github/workflows/action.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,151 @@
+# Changelog
+
+## [v1.0.4](https://github.com/fujiwara/lambroll/compare/v1.1.3...v1.0.4) - 2025-01-07
+
+## [v1.1.3](https://github.com/fujiwara/lambroll/compare/v1.1.2...v1.1.3) - 2024-10-30
+- fix: lambroll diff to ignore unchanged VpcConfig.Ipv6AllowedForDualStack values by @mackee in https://github.com/fujiwara/lambroll/pull/443
+
+## [v1.1.2](https://github.com/fujiwara/lambroll/compare/v1.1.0...v1.1.2) - 2024-10-02
+- Bump github.com/fujiwara/tfstate-lookup from 1.3.2 to 1.4.2 by @dependabot in https://github.com/fujiwara/lambroll/pull/439
+- Bump golang.org/x/sys from 0.24.0 to 0.25.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/438
+- Bump the aws-sdk-go-v2 group with 5 updates by @dependabot in https://github.com/fujiwara/lambroll/pull/437
+- fix: Correct color configuration in CLI by @soh335 in https://github.com/fujiwara/lambroll/pull/436
+- --no-color also works. by @fujiwara in https://github.com/fujiwara/lambroll/pull/441
+
+## [v1.1.1](https://github.com/fujiwara/lambroll/compare/v0.14.6...v1.1.1) - 2023-11-21
+- support LoggingConfig by @fujiwara in https://github.com/fujiwara/lambroll/pull/334
+
+## [v1.1.0](https://github.com/fujiwara/lambroll/compare/v1.0.6...v1.1.0) - 2024-09-02
+- Add Jsonnet native functions. by @fujiwara in https://github.com/fujiwara/lambroll/pull/429
+- Add --symlink to archive symlinks as is. by @fujiwara in https://github.com/fujiwara/lambroll/pull/430
+- Bump the aws-sdk-go-v2 group with 5 updates by @dependabot in https://github.com/fujiwara/lambroll/pull/431
+- Bump github.com/fatih/color from 1.16.0 to 1.17.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/435
+- Bump github.com/samber/lo from 1.44.0 to 1.47.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/434
+- Bump github.com/go-test/deep from 1.1.0 to 1.1.1 by @dependabot in https://github.com/fujiwara/lambroll/pull/433
+- Bump golang.org/x/sys from 0.22.0 to 0.24.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/432
+
+## [v1.0.6](https://github.com/fujiwara/lambroll/compare/v1.0.5...v1.0.6) - 2024-08-09
+- update readme: deploy via s3 by @fujiwara in https://github.com/fujiwara/lambroll/pull/421
+- treat symlink as file when adding to zip / #402 by @fujiwara in https://github.com/fujiwara/lambroll/pull/422
+- chore: treat symlink as file when adding to zip by @j3tm0t0 in https://github.com/fujiwara/lambroll/pull/402
+- Bump the aws-sdk-go-v2 group across 1 directory with 5 updates by @dependabot in https://github.com/fujiwara/lambroll/pull/424
+- Bump github.com/shogo82148/go-retry from 1.1.1 to 1.3.1 by @dependabot in https://github.com/fujiwara/lambroll/pull/423
+- Bump github.com/fujiwara/ssm-lookup from 0.0.1 to 0.1.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/419
+- update go-jq and kong to latest by @fujiwara in https://github.com/fujiwara/lambroll/pull/425
+- feat(action.yml): auto detect os and arch by @bungoume in https://github.com/fujiwara/lambroll/pull/417
+- V1 actions test by @fujiwara in https://github.com/fujiwara/lambroll/pull/426
+- Fix/actions bash3 by @fujiwara in https://github.com/fujiwara/lambroll/pull/427
+
+## [v1.0.5](https://github.com/fujiwara/lambroll/compare/v1.0.4...v1.0.5) - 2024-07-10
+- Bump golang.org/x/net from 0.17.0 to 0.23.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/395
+- set empty list to Layers explicitly by @fujiwara in https://github.com/fujiwara/lambroll/pull/404
+- fix fillDefaultValues by @fujiwara in https://github.com/fujiwara/lambroll/pull/405
+- fix: default LoggingConfig by @fujiwara in https://github.com/fujiwara/lambroll/pull/414
+- fix: for goreleaser v2 by @fujiwara in https://github.com/fujiwara/lambroll/pull/413
+- feat(action.yml): add os and arch options by @rinx in https://github.com/fujiwara/lambroll/pull/412
+- Bump goreleaser/goreleaser-action from 5 to 6 by @dependabot in https://github.com/fujiwara/lambroll/pull/411
+- Bump github.com/hashicorp/go-retryablehttp from 0.7.1 to 0.7.7 by @dependabot in https://github.com/fujiwara/lambroll/pull/406
+- Bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.3.1 to 1.6.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/401
+- Bump golang.org/x/sys from 0.20.0 to 0.22.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/415
+- update to google.golang.org/grpc@v1.56.3 by @fujiwara in https://github.com/fujiwara/lambroll/pull/416
+- Bump the aws-sdk-go-v2 group across 1 directory with 4 updates by @dependabot in https://github.com/fujiwara/lambroll/pull/410
+- Bump github.com/samber/lo from 1.38.1 to 1.44.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/407
+- Bump github.com/google/go-cmp from 0.5.9 to 0.6.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/372
+
+## [v1.0.4](https://github.com/fujiwara/lambroll/compare/v1.0.3...v1.0.4) - 2024-04-19
+- fix spelling. by @fujiwara in https://github.com/fujiwara/lambroll/pull/391
+- update tfstate-lookup to v1.1.6 by @fujiwara in https://github.com/fujiwara/lambroll/pull/393
+- Fix: `--ignore .ImageConfig` didn't work. by @fujiwara in https://github.com/fujiwara/lambroll/pull/394
+- Support CloudFront OAC by @fujiwara in https://github.com/fujiwara/lambroll/pull/392
+
+## [v1.0.3](https://github.com/fujiwara/lambroll/compare/v1.0.2...v1.0.3) - 2024-04-05
+- no need to check the aliased version before deleting. by @fujiwara in https://github.com/fujiwara/lambroll/pull/390
+- Bump github.com/kayac/go-config from 0.6.0 to 0.7.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/375
+
+## [v1.0.2](https://github.com/fujiwara/lambroll/compare/v1.0.1...v1.0.2) - 2024-03-29
+- fix typo by @fujiwara in https://github.com/fujiwara/lambroll/pull/359
+- add --payload flag to invoke command. by @fujiwara in https://github.com/fujiwara/lambroll/pull/362
+- fix jsondiff version to released. by @fujiwara in https://github.com/fujiwara/lambroll/pull/363
+- version fix docs and samples by @yjszk in https://github.com/fujiwara/lambroll/pull/367
+- Bump golang.org/x/net from 0.14.0 to 0.17.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/365
+- Bump google.golang.org/protobuf from 1.26.0 to 1.33.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/378
+- Bump golang.org/x/crypto from 0.12.0 to 0.17.0 by @dependabot in https://github.com/fujiwara/lambroll/pull/364
+- add init --force-overwrite flag. by @fujiwara in https://github.com/fujiwara/lambroll/pull/377
+- Support to `rollback --alias`. by @fujiwara in https://github.com/fujiwara/lambroll/pull/366
+
+## [v1.0.1](https://github.com/fujiwara/lambroll/compare/v1.0.0...v1.0.1) - 2024-02-14
+- Fix options for compatibility with previous versions by @miztch in https://github.com/fujiwara/lambroll/pull/358
+
+## [v1.0.0](https://github.com/fujiwara/lambroll/compare/v0.14.4...v1.0.0) - 2024-02-08
+- Ignore on deploy by @fujiwara in https://github.com/fujiwara/lambroll/pull/283
+- aws-sdk-go-v2 by @fujiwara in https://github.com/fujiwara/lambroll/pull/306
+- use Kong instead of kingpin. by @fujiwara in https://github.com/fujiwara/lambroll/pull/315
+- update tfstate-lookup v1.1.4 by @fujiwara in https://github.com/fujiwara/lambroll/pull/316
+- docs: add the installation guide with aqua by @suzuki-shunsuke in https://github.com/fujiwara/lambroll/pull/318
+- dependabot for actions by @fujiwara in https://github.com/fujiwara/lambroll/pull/304
+- Ssm plugin by @fujiwara in https://github.com/fujiwara/lambroll/pull/319
+- Add render subcommand by @fujiwara in https://github.com/fujiwara/lambroll/pull/326
+- V1/archive by @fujiwara in https://github.com/fujiwara/lambroll/pull/327
+- fix: added zero value check for ImageConfigRespose by @ponkio-o in https://github.com/fujiwara/lambroll/pull/329
+- add diff -u by default by @fujiwara in https://github.com/fujiwara/lambroll/pull/328
+- Support LoggingConfig (for v1) by @fujiwara in https://github.com/fujiwara/lambroll/pull/333
+- Add status command by @fujiwara in https://github.com/fujiwara/lambroll/pull/336
+- add deploy --function-url feature by @fujiwara in https://github.com/fujiwara/lambroll/pull/330
+- lambroll status should be simple by @fujiwara in https://github.com/fujiwara/lambroll/pull/344
+- accept LAMBROLL_* environment variables as flag valueis. by @fujiwara in https://github.com/fujiwara/lambroll/pull/345
+- switch to goreleaser by @fujiwara in https://github.com/fujiwara/lambroll/pull/346
+- fix segfault when creating a new function. by @fujiwara in https://github.com/fujiwara/lambroll/pull/347
+- lambroll diff works even if the lambda function is not found. by @fujiwara in https://github.com/fujiwara/lambroll/pull/348
+- Fix/status by @fujiwara in https://github.com/fujiwara/lambroll/pull/349
+- Add --ignore flag to deploy and diff command. by @fujiwara in https://github.com/fujiwara/lambroll/pull/281
+- Fix/ignore env by @fujiwara in https://github.com/fujiwara/lambroll/pull/350
+- fix failed to diff when a remote function is not found. by @fujiwara in https://github.com/fujiwara/lambroll/pull/351
+- Fix/trace log by @fujiwara in https://github.com/fujiwara/lambroll/pull/352
+- init --function-url creates a default file by @fujiwara in https://github.com/fujiwara/lambroll/pull/353
+- Skip checking to update PackageType when the new function is created. by @fujiwara in https://github.com/fujiwara/lambroll/pull/354
+- fix diff output of function url. by @fujiwara in https://github.com/fujiwara/lambroll/pull/355
+- fix: deploy function url after create function. by @fujiwara in https://github.com/fujiwara/lambroll/pull/356
+
+## [v0.14.7](https://github.com/fujiwara/lambroll/compare/v0.14.6...v0.14.7) - 2023-11-21
+- support LoggingConfig by @fujiwara in https://github.com/fujiwara/lambroll/pull/334
+
+## [v0.14.6](https://github.com/fujiwara/lambroll/compare/v0.14.5...v0.14.6) - 2023-10-19
+- docs: add the installation guide with aqua by @suzuki-shunsuke in https://github.com/fujiwara/lambroll/pull/318
+- dependabot for actions by @fujiwara in https://github.com/fujiwara/lambroll/pull/304
+- fix: added zero value check for ImageConfigRespose by @ponkio-o in https://github.com/fujiwara/lambroll/pull/329
+
+## [v0.14.5](https://github.com/fujiwara/lambroll/compare/v0.14.4...v0.14.5) - 2023-10-06
+- update tfstate-lookup v1.1.4 by @fujiwara in https://github.com/fujiwara/lambroll/pull/316
+
+## [v0.14.4](https://github.com/fujiwara/lambroll/compare/v0.14.3...v0.14.4) - 2023-09-22
+- Add runtime to output of versions command. by @fujiwara in https://github.com/fujiwara/lambroll/pull/309
+- Wait until the function code has been successfully updated by @minamijoyo in https://github.com/fujiwara/lambroll/pull/314
+
+## [v0.14.3](https://github.com/fujiwara/lambroll/compare/v0.14.2...v0.14.3) - 2023-08-10
+- Reduce diff by @fujiwara in https://github.com/fujiwara/lambroll/pull/293
+- Added an option not listed in the README by @bungoume in https://github.com/fujiwara/lambroll/pull/277
+- fix readme by @fujiwara in https://github.com/fujiwara/lambroll/pull/294
+- Go 1.20 by @fujiwara in https://github.com/fujiwara/lambroll/pull/296
+- Fix readme edge by @fujiwara in https://github.com/fujiwara/lambroll/pull/305
+- fill ImageConfig on init by @chaya2z in https://github.com/fujiwara/lambroll/pull/307
+- reset ImageConfig explicitly when it is removed. by @fujiwara in https://github.com/fujiwara/lambroll/pull/308
+
+## [v0.14.2](https://github.com/fujiwara/lambroll/compare/v0.14.1...v0.14.2) - 2023-01-23
+- fix error handling on UpdateFunctionCode. by @fujiwara in https://github.com/fujiwara/lambroll/pull/289
+
+## [v0.14.1](https://github.com/fujiwara/lambroll/compare/v0.14.0...v0.14.1) - 2022-11-30
+- Fix panic on init by @fujiwara in https://github.com/fujiwara/lambroll/pull/276
+
+## [v0.14.0](https://github.com/fujiwara/lambroll/compare/v0.13.0...v0.14.0) - 2022-11-29
+- Support to SnapStart. by @fujiwara in https://github.com/fujiwara/lambroll/pull/273
+
+## [v0.13.0](https://github.com/fujiwara/lambroll/compare/v0.12.9...v0.13.0) - 2022-06-10
+- Support multiple tfstate files by @Liooo in https://github.com/fujiwara/lambroll/pull/236
+- fill default ephemeral storage size to 512 by @fujiwara in https://github.com/fujiwara/lambroll/pull/242
+- Fill default values to CreateFunctionInput before deploy. by @fujiwara in https://github.com/fujiwara/lambroll/pull/243
+- implements for diff --code by @fujiwara in https://github.com/fujiwara/lambroll/pull/232
+
+## [v0.12.9](https://github.com/fujiwara/lambroll/compare/v0.12.8...v0.12.9) - 2022-04-14
+- Bump github.com/aws/aws-sdk-go from 1.40.52 to 1.43.37 by @dependabot in https://github.com/fujiwara/lambroll/pull/226
+- Supports EphemeralStorage by @fujiwara in https://github.com/fujiwara/lambroll/pull/227
+- set default --function variable by @fujiwara in https://github.com/fujiwara/lambroll/pull/228

--- a/create.go
+++ b/create.go
@@ -34,6 +34,10 @@ func prepareZipfile(src string, excludes []string, keepSymlink bool) (*os.File, 
 }
 
 func (app *App) prepareFunctionCodeForDeploy(ctx context.Context, opt *DeployOption, fn *Function) error {
+	if fn.Layers == nil {
+		fn.Layers = []string{} // set explicitly
+	}
+
 	if fn.PackageType == types.PackageTypeImage {
 		if fn.Code == nil || fn.Code.ImageUri == nil {
 			return fmt.Errorf("PackageType=Image requires Code.ImageUri in function definition")


### PR DESCRIPTION
This pull request is for the next release as v1.0.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.1.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
**Full Changelog**: https://github.com/fujiwara/lambroll/compare/v1.1.3...v1.0.4