### PR TITLE
fix: use the del() function to ignore a given path

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -128,7 +128,16 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse ignore query: %w", err)
 		}
-		q = jsondiff.WithUpdate(q)
+		// Use the del() function to ignore a given path
+		q = &gojq.Query{
+			Term: &gojq.Term{
+				Type: gojq.TermTypeFunc,
+				Func: &gojq.Func{
+					Name: "del",
+					Args: []*gojq.Query{q},
+				},
+			},
+		}
 		fnAny, _ := marshalAny(fn)
 		fnAny, err = jsondiff.ModifyValue(q, fnAny)
 		if err != nil {


### PR DESCRIPTION
The lambroll uses [WithUpdate()](https://pkg.go.dev/github.com/aereal/jsondiff#WithUpdate) function to ignore the specified JSON path that going to be removed in the future for bad design.

This pull request changes `Deploy()` method to build gojq query manually instead of calling `WithUpdate()`.

If you pass the option such as `-ignore .name`, you got the query like `.name = null`, but now you will get the query like `del(.name)`.