### PR TITLE
Make the specification clear for overriding flag priorities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ The file format is JSON or Jsonnet.
 All fields are optional. If the field is not defined, the default value is used.
 When command-line flags are specified, they take precedence over the options file.
 
+The priority of the option values is as follows:
+
+1. Command-line flags. (`--log-level=debug`)
+2. The values defined in the option file. (`{"log_level": "debug"}`)
+3. Environment variables. (`LAMBROLL_LOGLEVEL=debug`)
+
 While parsing the option file, lambroll evaluates only the `{{env}}` and `{{must_env}}` template functions and `env` and `must_env` native functions in Jsonnet. Other functions are not available.
 
 ### Init

--- a/cli_test.go
+++ b/cli_test.go
@@ -131,7 +131,7 @@ var cliTests = []struct {
 			OptionFilePath: "override.jsonnet",
 			Color:          true,
 			Envfile:        []string{},
-			LogLevel:       "debug",
+			LogLevel:       "trace", // priority is higher than env
 			Profile:        ptr("mine"),
 			Region:         ptr("us-west-2"),
 		},

--- a/cli_test.go
+++ b/cli_test.go
@@ -131,7 +131,26 @@ var cliTests = []struct {
 			OptionFilePath: "override.jsonnet",
 			Color:          true,
 			Envfile:        []string{},
-			LogLevel:       "trace", // priority is higher than env
+			LogLevel:       "trace", // option file's priority is higher than env
+			Profile:        ptr("mine"),
+			Region:         ptr("us-west-2"),
+		},
+	},
+	{
+		args: []string{"render",
+			"--profile", "mine",
+			"--region", "us-west-2",
+		},
+		env: map[string]string{
+			"LAMBROLL_OPTION":    "override.jsonnet",
+			"LAMBROLL_LOG_LEVEL": "debug",
+		},
+		sub: "render",
+		option: &lambroll.Option{
+			OptionFilePath: "override.jsonnet",
+			Color:          true,
+			Envfile:        []string{},
+			LogLevel:       "trace", // option file's priority is higher than env
 			Profile:        ptr("mine"),
 			Region:         ptr("us-west-2"),
 		},

--- a/cli_test.go
+++ b/cli_test.go
@@ -118,6 +118,24 @@ var cliTests = []struct {
 		sub:  "render",
 		err:  os.ErrNotExist,
 	},
+	{
+		args: []string{"render", "--option", "override.jsonnet",
+			"--profile", "mine",
+			"--region", "us-west-2",
+		},
+		env: map[string]string{
+			"LAMBROLL_LOG_LEVEL": "debug",
+		},
+		sub: "render",
+		option: &lambroll.Option{
+			OptionFilePath: "override.jsonnet",
+			Color:          true,
+			Envfile:        []string{},
+			LogLevel:       "debug",
+			Profile:        ptr("mine"),
+			Region:         ptr("us-west-2"),
+		},
+	},
 }
 
 func TestParseCLI(t *testing.T) {

--- a/lambroll_test.go
+++ b/lambroll_test.go
@@ -85,3 +85,7 @@ func TestFillDefaultValues(t *testing.T) {
 		})
 	}
 }
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/test/cli/override.jsonnet
+++ b/test/cli/override.jsonnet
@@ -1,0 +1,5 @@
+{
+  profile: 'dummy',
+  region: 'us-east-1',
+  log_level: 'trace',
+}


### PR DESCRIPTION
Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R248-R253): Added a section detailing the priority of option values, specifying the order as command-line flags, option file values, and environment variables.

Test case enhancements:

* [`cli_test.go`](diffhunk://#diff-15cef7bb728146e2f3717c9d319094dca8175a53de9609127cc7b9b7adb30423R121-R157): Added new test cases to verify the priority of option values, ensuring that option file values take precedence over environment variables.

Codebase improvements:

* [`lambroll_test.go`](diffhunk://#diff-ee524a4135ffbf343dabcf39881e77ce5e3f0071a8edf48b78109cb3ee286984R88-R91): Introduced a new helper function `ptr` to simplify the creation of pointer values in tests.