### PR TITLE
Add hosted arm runner.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       matrix:
         env:
-          - runner: ubuntu-latest
+          - runner: ubuntu-24.04
+          - runner: ubuntu-24.04-arm
           - runner: macos-latest
     name: test action
     runs-on: ${{ matrix.env.runner }}


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file to update the runner environments used for testing.

* [`.github/workflows/action.yml`](diffhunk://#diff-ab5b4efba7d032a7065a9d242e7e1bd92b59251ab0c5c95b4a3aa6f1d0b38db7L14-R15): Updated the `runner` environments in the matrix strategy to include `ubuntu-24.04` and `ubuntu-24.04-arm`, replacing `ubuntu-latest`.