### PR TITLE
Fixed error handling for --keep-versions

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -226,7 +226,9 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 		}
 	}
 	if opt.KeepVersions > 0 { // Ignore zero-value.
-		return app.deleteVersions(ctx, *fn.FunctionName, opt.KeepVersions)
+		if err := app.deleteVersions(ctx, *fn.FunctionName, opt.KeepVersions); err != nil {
+			return err
+		}
 	}
 
 	if err := deployFunctionURL(ctx); err != nil {


### PR DESCRIPTION
When --keep-versions and --lambda-function-url are specified at the same time, the function URL is not deployed.

```
$lambroll deploy --function-url function_url.jsonnet --keep-versions 10 
```

this case not deploy lambda function url