### PR TITLE
add --skip-configuration to deploy command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,18 +280,24 @@ Usage: lambroll deploy
 deploy or create function
 
 Flags:
-      --src="."                           function zip archive or src dir
-      --publish                           publish function
-      --alias="current"                   alias name for publish
-      --alias-to-latest                   set alias to unpublished $LATEST version
-      --dry-run                           dry run
-      --skip-archive                      skip to create zip archive. requires Code.S3Bucket and Code.S3Key in function definition
-      --keep-versions=0                   Number of latest versions to keep. Older versions will be deleted. (Optional value: default 0).
-      --ignore=""                         ignore fields by jq queries in function.json
-      --function-url=""                   path to function-url definition ($LAMBROLL_FUNCTION_URL)
-      --skip-function                     skip to deploy a function. deploy function-url only
-      --exclude-file=".lambdaignore"      exclude file
-      --symlink                           keep symlink (same as zip --symlink,-y)
+      --src="."                   function zip archive or src dir
+      --publish                   publish function
+      --alias="current"           alias name for publish
+      --alias-to-latest           set alias to unpublished $LATEST version
+      --dry-run                   dry run
+      --skip-archive              skip to create zip archive. requires Code.S3Bucket
+                                  and Code.S3Key in function definition
+      --keep-versions=0           Number of latest versions to keep. Older versions
+                                  will be deleted. (Optional value: default 0).
+      --ignore=""                 ignore fields by jq queries in function.json
+      --function-url=""           path to function-url definition
+                                  ($LAMBROLL_FUNCTION_URL)
+      --skip-configuration        skip to update a configuration. deploy a function
+                                  code and aliases only
+      --skip-function             skip to deploy a function. deploy function-url only
+      --exclude-file=".lambdaignore"
+                                  exclude file
+      --symlink                   keep symlink (same as zip --symlink,-y)
 ```
 
 `deploy` works as below.
@@ -299,8 +305,27 @@ Flags:
 - Create a zip archive from `--src` directory.
   - Excludes files matched (wildcard pattern) in `--exclude-file`.
 - Create / Update Lambda function
+  - If the function does not exist, create a new function.
+  - If the function exists, update the function code.
+  - Create / Update function configuration
+    - If `--skip-configuration` is specified, skip to update the configuration.
+  - Create / Update function code
 - Create an alias to the published version when `--publish` (default).
 
+#### Ignore some configurations
+
+lambroll can ignore some fields in function.json by using `--ignore` flag.
+
+```console
+$ lambroll deploy --ignore='.Tags, .Environment'
+```
+When `--ignore` is specified, lambroll ignores the fields in function.json.
+
+To confirm the ignored fields, you can use `lambroll diff` command.
+
+```console
+$ lambroll diff --ignore='.Tags, .Environment'
+```
 
 #### Deploy via S3
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Flags:
       --ignore=""                 ignore fields by jq queries in function.json
       --function-url=""           path to function-url definition
                                   ($LAMBROLL_FUNCTION_URL)
-      --skip-configuration        skip to update a configuration. deploy a function
+      --skip-configuration        skip updating function configuration, deploy function
                                   code and aliases only
       --skip-function             skip to deploy a function. deploy function-url only
       --exclude-file=".lambdaignore"

--- a/deploy.go
+++ b/deploy.go
@@ -27,7 +27,7 @@ type DeployOption struct {
 	KeepVersions      int    `help:"Number of latest versions to keep. Older versions will be deleted. (Optional value: default 0)." default:"0"`
 	Ignore            string `help:"ignore fields by jq queries in function.json" default:""`
 	FunctionURL       string `help:"path to function-url definition" default:"" env:"LAMBROLL_FUNCTION_URL"`
-	SkipConfiguration bool   `help:"skip to update a configuration. deploy a function code and aliases only" default:"false"`
+	SkipConfiguration bool   `help:"skip updating function configuration, deploy function code and aliases only" default:"false"`
 	SkipFunction      bool   `help:"skip to deploy a function. deploy function-url only" default:"false"`
 
 	ZipOption

--- a/deploy.go
+++ b/deploy.go
@@ -18,16 +18,17 @@ import (
 
 // DeployOption represents an option for Deploy()
 type DeployOption struct {
-	Src           string `help:"function zip archive or src dir" default:"."`
-	Publish       bool   `help:"publish function" default:"true"`
-	AliasName     string `name:"alias" help:"alias name for publish" default:"current"`
-	AliasToLatest bool   `help:"set alias to unpublished $LATEST version" default:"false"`
-	DryRun        bool   `help:"dry run" default:"false"`
-	SkipArchive   bool   `help:"skip to create zip archive. requires Code.S3Bucket and Code.S3Key in function definition" default:"false"`
-	KeepVersions  int    `help:"Number of latest versions to keep. Older versions will be deleted. (Optional value: default 0)." default:"0"`
-	Ignore        string `help:"ignore fields by jq queries in function.json" default:""`
-	FunctionURL   string `help:"path to function-url definition" default:"" env:"LAMBROLL_FUNCTION_URL"`
-	SkipFunction  bool   `help:"skip to deploy a function. deploy function-url only" default:"false"`
+	Src               string `help:"function zip archive or src dir" default:"."`
+	Publish           bool   `help:"publish function" default:"true"`
+	AliasName         string `name:"alias" help:"alias name for publish" default:"current"`
+	AliasToLatest     bool   `help:"set alias to unpublished $LATEST version" default:"false"`
+	DryRun            bool   `help:"dry run" default:"false"`
+	SkipArchive       bool   `help:"skip to create zip archive. requires Code.S3Bucket and Code.S3Key in function definition" default:"false"`
+	KeepVersions      int    `help:"Number of latest versions to keep. Older versions will be deleted. (Optional value: default 0)." default:"0"`
+	Ignore            string `help:"ignore fields by jq queries in function.json" default:""`
+	FunctionURL       string `help:"path to function-url definition" default:"" env:"LAMBROLL_FUNCTION_URL"`
+	SkipConfiguration bool   `help:"skip to update a configuration. deploy a function code and aliases only" default:"false"`
+	SkipFunction      bool   `help:"skip to deploy a function. deploy function-url only" default:"false"`
 
 	ZipOption
 }
@@ -148,6 +149,47 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 		unmarshalJSON(src, &fn, app.functionFilePath)
 	}
 
+	// update function configuration
+	if opt.SkipConfiguration {
+		log.Println("[info] skip to deploy function configuration", opt.label())
+	} else {
+		if err := app.deployFunctionConfiguration(ctx, fn, opt); err != nil {
+			return fmt.Errorf("failed to deploy function configuration: %w", err)
+		}
+	}
+
+	// update function code
+	newerVersion, err := app.deployFunctionCode(ctx, fn, opt)
+	if err != nil {
+		return fmt.Errorf("failed to deploy function code: %w", err)
+	}
+
+	if opt.DryRun {
+		return nil
+	}
+
+	// update function aliases
+	if opt.Publish || opt.AliasToLatest {
+		err := app.updateAliases(ctx, *fn.FunctionName, versionAlias{newerVersion, opt.AliasName})
+		if err != nil {
+			return err
+		}
+	}
+	if opt.KeepVersions > 0 { // Ignore zero-value.
+		if err := app.deleteVersions(ctx, *fn.FunctionName, opt.KeepVersions); err != nil {
+			return err
+		}
+	}
+
+	// deploy function-url
+	if err := deployFunctionURL(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (app *App) deployFunctionConfiguration(ctx context.Context, fn *Function, opt *DeployOption) error {
 	log.Println("[info] updating function configuration", opt.label())
 	confIn := &lambda.UpdateFunctionConfigurationInput{
 		DeadLetterConfig:  fn.DeadLetterConfig,
@@ -171,7 +213,6 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 	}
 	log.Printf("[debug] %s", jsonStr(confIn))
 
-	var newerVersion string
 	if !opt.DryRun {
 		proc := func(ctx context.Context) error {
 			return app.updateFunctionConfiguration(ctx, confIn)
@@ -183,7 +224,10 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 	if err := app.updateTags(ctx, fn, opt); err != nil {
 		return err
 	}
+	return nil
+}
 
+func (app *App) deployFunctionCode(ctx context.Context, fn *Function, opt *DeployOption) (string, error) {
 	codeIn := &lambda.UpdateFunctionCodeInput{
 		Architectures:   fn.Architectures,
 		FunctionName:    fn.FunctionName,
@@ -207,8 +251,9 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 		return err
 	}
 	if err := app.ensureLastUpdateStatusSuccessful(ctx, *fn.FunctionName, "updating function code", proc, opt.label()); err != nil {
-		return err
+		return "", err
 	}
+	var newerVersion string
 	if res.Version != nil {
 		newerVersion = *res.Version
 		log.Printf("[info] deployed version %s %s", *res.Version, opt.label())
@@ -216,26 +261,7 @@ func (app *App) Deploy(ctx context.Context, opt *DeployOption) error {
 		newerVersion = versionLatest
 		log.Printf("[info] deployed version %s %s", newerVersion, opt.label())
 	}
-	if opt.DryRun {
-		return nil
-	}
-	if opt.Publish || opt.AliasToLatest {
-		err := app.updateAliases(ctx, *fn.FunctionName, versionAlias{newerVersion, opt.AliasName})
-		if err != nil {
-			return err
-		}
-	}
-	if opt.KeepVersions > 0 { // Ignore zero-value.
-		if err := app.deleteVersions(ctx, *fn.FunctionName, opt.KeepVersions); err != nil {
-			return err
-		}
-	}
-
-	if err := deployFunctionURL(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return newerVersion, nil
 }
 
 func (app *App) updateFunctionConfiguration(ctx context.Context, in *lambda.UpdateFunctionConfigurationInput) error {


### PR DESCRIPTION
A `--skip-configuration` flag skips calling the UpdateFunctionConfiguration API.

-  #497

This pull request introduces the `--skip-configuration` flag to allow skipping the deployment of function configurations, refactors the deployment process for better modularity, and updates the documentation to reflect these changes. Below are the most important changes grouped by theme:

### New Feature: `--skip-configuration` Flag
* Added the `--skip-configuration` flag to the `DeployOption` struct in `deploy.go`, enabling users to skip updating function configurations during deployment.
* Updated the `Deploy` method in `deploy.go` to conditionally skip configuration updates if the `--skip-configuration` flag is set.

### Refactoring: Modular Deployment Functions
* Extracted the logic for deploying function configurations into a new `deployFunctionConfiguration` method for better code modularity.
* Extracted the logic for deploying function code into a new `deployFunctionCode` method, returning the deployed version for further processing.
* Simplified the `Deploy` method by delegating specific tasks (e.g., configuration and code updates) to the newly created methods. [[1]](diffhunk://#diff-f6f12c44b5abae039aa0020f2cbfd1d5d200995c3ea850716939d204ce6a773fL174) [[2]](diffhunk://#diff-f6f12c44b5abae039aa0020f2cbfd1d5d200995c3ea850716939d204ce6a773fL210-R264)

### Documentation Updates
* Updated the `README.md` to include descriptions and examples for the new `--skip-configuration` flag, along with other minor formatting improvements for better readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L288-R299) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R308-R328)