### PR TITLE
ignore AWS managed tags for tag/untag operation.

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -17,7 +17,7 @@ var (
 	NewCallerIdentity       = newCallerIdentity
 	Unzip                   = unzip
 	ExtractExitCodeAndError = extractExitCodeAndError
-	IsAWSManagedTags        = isAWSManagedTags
+	IsAWSManagedTag         = isAWSManagedTag
 )
 
 type VersionsOutput = versionsOutput

--- a/export_test.go
+++ b/export_test.go
@@ -17,6 +17,7 @@ var (
 	NewCallerIdentity       = newCallerIdentity
 	Unzip                   = unzip
 	ExtractExitCodeAndError = extractExitCodeAndError
+	IsAWSManagedTags        = isAWSManagedTags
 )
 
 type VersionsOutput = versionsOutput

--- a/tags.go
+++ b/tags.go
@@ -35,10 +35,10 @@ func (app *App) updateTags(ctx context.Context, fn *Function, opt *DeployOption)
 	setTags, removeTagKeys := mergeTags(tags.Tags, fn.Tags)
 	// ignore AWS managed tags because they are not allowed to be modified
 	setTags = lo.OmitBy(setTags, func(tag string, _ string) bool {
-		return isAWSManagedTags(tag)
+		return isAWSManagedTag(tag)
 	})
 	removeTagKeys = lo.Reject(removeTagKeys, func(tag string, _ int) bool {
-		return isAWSManagedTags(tag)
+		return isAWSManagedTag(tag)
 	})
 
 	if len(setTags) == 0 && len(removeTagKeys) == 0 {
@@ -99,7 +99,7 @@ func mergeTags(oldTags, newTags Tags) (sets Tags, removes []string) {
 	return
 }
 
-func isAWSManagedTags(tag string) bool {
+func isAWSManagedTag(tag string) bool {
 	if strings.HasPrefix(strings.ToLower(tag), "aws:") {
 		log.Printf("[info] ignoring AWS managed tag %s", tag)
 		return true

--- a/tags.go
+++ b/tags.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/samber/lo"
 )
 
 func (app *App) updateTags(ctx context.Context, fn *Function, opt *DeployOption) error {
@@ -31,6 +33,13 @@ func (app *App) updateTags(ctx context.Context, fn *Function, opt *DeployOption)
 	log.Printf("[debug] %d tags found", len(tags.Tags))
 
 	setTags, removeTagKeys := mergeTags(tags.Tags, fn.Tags)
+	// ignore AWS managed tags because they are not allowed to be modified
+	setTags = lo.OmitBy(setTags, func(tag string, _ string) bool {
+		return isAWSManagedTags(tag)
+	})
+	removeTagKeys = lo.Reject(removeTagKeys, func(tag string, _ int) bool {
+		return isAWSManagedTags(tag)
+	})
 
 	if len(setTags) == 0 && len(removeTagKeys) == 0 {
 		log.Println("[debug] no need to update tags (unchanged)")
@@ -88,4 +97,12 @@ func mergeTags(oldTags, newTags Tags) (sets Tags, removes []string) {
 		}
 	}
 	return
+}
+
+func isAWSManagedTags(tag string) bool {
+	if strings.HasPrefix(strings.ToLower(tag), "aws:") {
+		log.Printf("[info] ignoring AWS managed tag %s", tag)
+		return true
+	}
+	return false
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -79,7 +79,7 @@ var testTags = []struct {
 
 func TestIsAWSManagedTags(t *testing.T) {
 	for _, c := range testTags {
-		if lambroll.IsAWSManagedTags(c.name) != c.isAWSManaged {
+		if lambroll.IsAWSManagedTag(c.name) != c.isAWSManaged {
 			t.Errorf("unexpected result for tag name %s", c.name)
 		}
 	}

--- a/tags_test.go
+++ b/tags_test.go
@@ -58,3 +58,29 @@ func TestMergeTags(t *testing.T) {
 		}
 	}
 }
+
+var testTags = []struct {
+	name         string
+	isAWSManaged bool
+}{
+	{
+		name:         "aws:cloudformation:stack-name",
+		isAWSManaged: true,
+	},
+	{
+		name:         "AWS:cloudformation:logical-id",
+		isAWSManaged: true,
+	},
+	{
+		name:         "foo:bar",
+		isAWSManaged: false,
+	},
+}
+
+func TestIsAWSManagedTags(t *testing.T) {
+	for _, c := range testTags {
+		if lambroll.IsAWSManagedTags(c.name) != c.isAWSManaged {
+			t.Errorf("unexpected result for tag name %s", c.name)
+		}
+	}
+}


### PR DESCRIPTION
AWS managed tags cannot be modified.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
> The aws: prefix is reserved for AWS use. This prefix is case-insensitive.
> If you use this prefix in the Key or Value property, you can't update or delete the tag.

See also: https://tech.every.tv/entry/2025/04/15/115910