### PR TITLE
Add backward compatibility for extstr/extcode fields

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -32,6 +32,7 @@ type Option struct {
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling to support both old and new field names
+// TODO: Remove backward compatibility for extstr/extcode fields in v2
 func (o *Option) UnmarshalJSON(data []byte) error {
 	// Define a type alias to avoid infinite recursion
 	type Alias Option

--- a/cli.go
+++ b/cli.go
@@ -31,6 +31,34 @@ type Option struct {
 	ExtCode         map[string]string `help:"external code values for Jsonnet" env:"LAMBROLL_EXTCODE" json:"ext_code,omitempty"`
 }
 
+// UnmarshalJSON implements custom JSON unmarshaling to support both old and new field names
+func (o *Option) UnmarshalJSON(data []byte) error {
+	// Define a type alias to avoid infinite recursion
+	type Alias Option
+	aux := &struct {
+		*Alias
+		// Support old field names
+		OldExtStr  map[string]string `json:"extstr,omitempty"`
+		OldExtCode map[string]string `json:"extcode,omitempty"`
+	}{
+		Alias: (*Alias)(o),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// If old field names are used and new ones are empty, copy the values
+	if o.ExtStr == nil && aux.OldExtStr != nil {
+		o.ExtStr = aux.OldExtStr
+	}
+	if o.ExtCode == nil && aux.OldExtCode != nil {
+		o.ExtCode = aux.OldExtCode
+	}
+
+	return nil
+}
+
 type CLIOptions struct {
 	Option
 

--- a/cli.go
+++ b/cli.go
@@ -51,9 +51,11 @@ func (o *Option) UnmarshalJSON(data []byte) error {
 	// If old field names are used and new ones are empty, copy the values
 	if o.ExtStr == nil && aux.OldExtStr != nil {
 		o.ExtStr = aux.OldExtStr
+		log.Printf("[warn] Using deprecated field name 'extstr' in option file. Please use 'ext_str' instead.")
 	}
 	if o.ExtCode == nil && aux.OldExtCode != nil {
 		o.ExtCode = aux.OldExtCode
+		log.Printf("[warn] Using deprecated field name 'extcode' in option file. Please use 'ext_code' instead.")
 	}
 
 	return nil

--- a/cli_option_test.go
+++ b/cli_option_test.go
@@ -1,0 +1,88 @@
+package lambroll_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/fujiwara/lambroll"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOptionUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData string
+		want     lambroll.Option
+	}{
+		{
+			name: "new format with ext_str and ext_code",
+			jsonData: `{
+				"ext_str": {"key1": "value1", "key2": "value2"},
+				"ext_code": {"code1": "1+1", "code2": "2*2"}
+			}`,
+			want: lambroll.Option{
+				ExtStr:  map[string]string{"key1": "value1", "key2": "value2"},
+				ExtCode: map[string]string{"code1": "1+1", "code2": "2*2"},
+			},
+		},
+		{
+			name: "legacy format with extstr and extcode",
+			jsonData: `{
+				"extstr": {"key1": "value1", "key2": "value2"},
+				"extcode": {"code1": "1+1", "code2": "2*2"}
+			}`,
+			want: lambroll.Option{
+				ExtStr:  map[string]string{"key1": "value1", "key2": "value2"},
+				ExtCode: map[string]string{"code1": "1+1", "code2": "2*2"},
+			},
+		},
+		{
+			name: "mixed format (new format takes precedence)",
+			jsonData: `{
+				"ext_str": {"key1": "new_value"},
+				"extstr": {"key1": "old_value"},
+				"ext_code": {"code1": "new_code"},
+				"extcode": {"code1": "old_code"}
+			}`,
+			want: lambroll.Option{
+				ExtStr:  map[string]string{"key1": "new_value"},
+				ExtCode: map[string]string{"code1": "new_code"},
+			},
+		},
+		{
+			name: "empty fields",
+			jsonData: `{}`,
+			want: lambroll.Option{},
+		},
+		{
+			name: "with other fields",
+			jsonData: `{
+				"region": "us-west-2",
+				"profile": "default",
+				"extstr": {"key": "value"},
+				"log_level": "debug"
+			}`,
+			want: lambroll.Option{
+				ExtStr: map[string]string{"key": "value"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got lambroll.Option
+			err := json.Unmarshal([]byte(tt.jsonData), &got)
+			if err != nil {
+				t.Fatalf("UnmarshalJSON error = %v", err)
+			}
+
+			// Compare only the ExtStr and ExtCode fields
+			if diff := cmp.Diff(tt.want.ExtStr, got.ExtStr); diff != "" {
+				t.Errorf("ExtStr mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.want.ExtCode, got.ExtCode); diff != "" {
+				t.Errorf("ExtCode mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -173,6 +173,24 @@ var cliTests = []struct {
 			},
 		},
 	},
+	{
+		args: []string{"render", "--option", "ext_legacy.jsonnet"},
+		sub:  "render",
+		option: &lambroll.Option{
+			OptionFilePath: "ext_legacy.jsonnet",
+			Color:          true,
+			Envfile:        []string{},
+			ExtStr: map[string]string{
+				"architecture": "arm64",
+				"description":  "Legacy format test function",
+			},
+			ExtCode: map[string]string{
+				"memory_size":  "256",
+				"storage_size": "1024",
+				"timeout":      "10",
+			},
+		},
+	},
 }
 
 func TestParseCLI(t *testing.T) {

--- a/function_test.go
+++ b/function_test.go
@@ -106,7 +106,7 @@ func TestLoadFunction(t *testing.T) {
 		expectedJSON, _ := lambroll.MarshalJSON(expected)
 		fnJSON, _ := lambroll.MarshalJSON(fn)
 		if diff := cmp.Diff(string(expectedJSON), string(fnJSON), ignore); diff != "" {
-			t.Errorf("unexpected function got %s", diff)
+			t.Errorf("%s: unexpected function got %s", f, diff)
 		}
 	}
 }

--- a/test/cli/ext_legacy.jsonnet
+++ b/test/cli/ext_legacy.jsonnet
@@ -1,0 +1,12 @@
+{
+  // Legacy format using extstr and extcode (before v1.1.0)
+  extstr: {
+    architecture: "arm64",
+    description: "Legacy format test function",
+  },
+  extcode: {
+    memory_size: "256",
+    storage_size: "1024",
+    timeout: "10",
+  },
+}


### PR DESCRIPTION
## Summary
- Add backward compatibility for legacy `extstr`/`extcode` field names
- Support both old (`extstr`/`extcode`) and new (`ext_str`/`ext_code`) field names in option files
- Maintain compatibility with existing option files while supporting the documented format
- Add deprecation warnings when using legacy field names

## Problem
PR #508 changed the JSON field names from `extstr`/`extcode` to `ext_str`/`ext_code` to match the documentation, but this broke backward compatibility with existing option files using the old field names.

## Solution
Implemented a custom `UnmarshalJSON` method for the `Option` struct that:
- Accepts both old and new field names
- Prioritizes new field names when both are present
- Logs deprecation warnings when legacy field names are used
- Ensures smooth migration without breaking existing configurations

## Notes
- Backward compatibility for `extstr`/`extcode` fields will be removed in v2 (see TODO comment)
- Users are encouraged to migrate to the new field names `ext_str`/`ext_code`

## Test plan
- [x] Added unit tests for the `UnmarshalJSON` method covering all scenarios
- [x] Added CLI test with legacy format option file
- [x] All existing tests pass
- [x] Verified both formats work correctly
- [x] Verified deprecation warnings are displayed for legacy format

🤖 Generated with [Claude Code](https://claude.ai/code)