### PR TITLE
Add args inputs to run lambroll after installation.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -34,3 +34,8 @@ jobs:
           version-file: .test-lambroll-version
       - run: |
           lambroll version 2>&1 | fgrep v1.1.3
+
+      - uses: fujiwara/lambroll@v1-actions-test
+        with:
+          version: v1.3.2
+          args: version

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ jobs:
 
 ### GitHub Actions
 
-Action fujiwara/lambroll@v1 installs lambroll binary for Linux into /usr/local/bin. This action runs install only.
+Action fujiwara/lambroll@v1 installs lambroll binary for Linux into /usr/local/bin.
+
+This action installs the specified version of lambroll.
 
 ```yml
 jobs:
@@ -85,6 +87,15 @@ jobs:
           # version-file: .lambroll-version
       - run: |
           lambroll deploy
+```
+
+When the args input is specified, the command `lambroll {args}` is executed after the installation.
+
+```yaml
+      - uses: fujiwara/lambroll@v1
+        with:
+          version: v1.3.2
+          args: deploy
 ```
 
 Note:

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
   version-file:
     description: "File name that contains the lambroll version."
     required: false
+  args:
+    description: "Arguments to pass to lambroll"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -42,3 +46,8 @@ runs:
         curl -sL https://github.com/fujiwara/lambroll/releases/download/${{ steps.set-lambroll-version.outputs.VERSION }}/${{ steps.set-filename.outputs.FILENAME }} | tar zxvf -
         sudo install lambroll /usr/local/bin
       shell: bash
+    - name: Run lambroll
+      run: |
+        lambroll ${{ inputs.args }}
+      shell: bash
+      if: ${{ inputs.args != '' }}


### PR DESCRIPTION
When the args input is specified, the command `lambroll {args}` is executed after the installation.

```yaml
      - uses: fujiwara/lambroll@v1
        with:
          version: v1.3.2
          args: deploy
```
