### PR TITLE
Add --log-format option (text|json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Flags:
       --option=STRING                     option file path ($LAMBROLL_OPTION)
       --function=STRING                   Function file path ($LAMBROLL_FUNCTION)
       --log-level="info"                  log level (trace, debug, info, warn, error) ($LAMBROLL_LOGLEVEL)
+      --log-format="text"                 log format (text, json) ($LAMBROLL_LOGFORMAT)
       --[no-]color                        enable colored output ($LAMBROLL_COLOR)
       --region=REGION                     AWS region ($AWS_REGION)
       --profile=PROFILE                   AWS credential profile name ($AWS_PROFILE)
@@ -274,7 +275,7 @@ These flags can be set by environment variables or option file (`--option`).
 
 #### Environment variables
 
-For example, `--log-level=debug` can be set by `LAMBROLL_LOGLEVEL=debug`.
+For example, `--log-level=debug` can be set by `LAMBROLL_LOGLEVEL=debug`, and `--log-format=json` can be set by `LAMBROLL_LOGFORMAT=json`.
 
 See the above usage for the environment variable names.
 
@@ -290,6 +291,7 @@ The file format is JSON or Jsonnet.
 // option.jsonnet
 {
   log_level: 'info',
+  log_format: 'text',  // or 'json'
   color: true,
   region: 'ap-northeast-1',
   profile: 'default',
@@ -314,9 +316,9 @@ When command-line flags are specified, they take precedence over the options fil
 
 The priority of the option values is as follows:
 
-1. Command-line flags. (`--log-level=debug`)
-2. The values defined in the option file. (`{"log_level": "debug"}`)
-3. Environment variables. (`LAMBROLL_LOGLEVEL=debug`)
+1. Command-line flags. (`--log-level=debug`, `--log-format=json`)
+2. The values defined in the option file. (`{"log_level": "debug", "log_format": "json"}`)
+3. Environment variables. (`LAMBROLL_LOGLEVEL=debug`, `LAMBROLL_LOGFORMAT=json`)
 
 While parsing the option file, lambroll evaluates only the `{{env}}` and `{{must_env}}` template functions and `env` and `must_env` native functions in Jsonnet. Other functions are not available.
 

--- a/cli.go
+++ b/cli.go
@@ -20,6 +20,7 @@ type Option struct {
 	OptionFilePath string `help:"option file path" env:"LAMBROLL_OPTION" name:"option" json:"-"`
 	Function       string `help:"Function file path" env:"LAMBROLL_FUNCTION" json:"function,omitempty"`
 	LogLevel       string `help:"log level (trace, debug, info, warn, error)" default:"info" enum:",trace,debug,info,warn,error" env:"LAMBROLL_LOGLEVEL" json:"log_level"`
+	LogFormat      string `help:"log format (text, json)" default:"text" enum:",text,json" env:"LAMBROLL_LOGFORMAT" json:"log_format"`
 	Color          bool   `help:"enable colored output" default:"true" env:"LAMBROLL_COLOR" negatable:"" json:"color,omitempty"`
 
 	Region          *string           `help:"AWS region" env:"AWS_REGION" json:"region,omitempty"`
@@ -161,6 +162,9 @@ func CLI(ctx context.Context, parse CLIParseFunc) (int, error) {
 	if opts.LogLevel == "" {
 		opts.LogLevel = DefaultLogLevel
 	}
+	if opts.LogFormat == "" {
+		opts.LogFormat = "text"
+	}
 	logLevel := new(slog.LevelVar)
 	switch opts.LogLevel {
 	case "trace":
@@ -176,13 +180,24 @@ func CLI(ctx context.Context, parse CLIParseFunc) (int, error) {
 	default:
 		logLevel.Set(slog.LevelInfo)
 	}
-	slogHandlerOptions := &sloghandler.HandlerOptions{
-		Color: opts.Color,
-		HandlerOptions: slog.HandlerOptions{
+
+	var logger *slog.Logger
+	switch opts.LogFormat {
+	case "json":
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			Level: logLevel,
-		},
+		}))
+	case "text":
+		fallthrough
+	default:
+		slogHandlerOptions := &sloghandler.HandlerOptions{
+			Color: opts.Color,
+			HandlerOptions: slog.HandlerOptions{
+				Level: logLevel,
+			},
+		}
+		logger = slog.New(sloghandler.NewLogHandler(os.Stderr, slogHandlerOptions))
 	}
-	logger := slog.New(sloghandler.NewLogHandler(os.Stderr, slogHandlerOptions))
 	slog.SetDefault(logger)
 
 	err = dispatchCLI(ctx, sub, usage, opts)

--- a/cli_test.go
+++ b/cli_test.go
@@ -21,9 +21,10 @@ var cliTests = []struct {
 		args: []string{"render"},
 		sub:  "render",
 		option: &lambroll.Option{
-			LogLevel: "info",
-			Color:    true,
-			Envfile:  []string{},
+			LogLevel:  "info",
+			LogFormat: "text",
+			Color:     true,
+			Envfile:   []string{},
 		},
 	},
 	{
@@ -40,9 +41,10 @@ var cliTests = []struct {
 		args: []string{"render", "--envfile=envfile.global"},
 		sub:  "render",
 		option: &lambroll.Option{
-			LogLevel: "info",
-			Color:    true,
-			Envfile:  []string{"envfile.global"},
+			LogLevel:  "info",
+			LogFormat: "text",
+			Color:     true,
+			Envfile:   []string{"envfile.global"},
 		},
 	},
 	{
@@ -67,9 +69,10 @@ var cliTests = []struct {
 		},
 		sub: "render",
 		option: &lambroll.Option{
-			LogLevel: "info",
-			Color:    true,
-			Envfile:  []string{"envfile.global", "envfile.local"},
+			LogLevel:  "info",
+			LogFormat: "text",
+			Color:     true,
+			Envfile:   []string{"envfile.global", "envfile.local"},
 		},
 	},
 	{
@@ -80,9 +83,10 @@ var cliTests = []struct {
 			"LAMBROLL_COLOR":    "false",
 		},
 		option: &lambroll.Option{
-			LogLevel: "error",
-			Color:    false,
-			Envfile:  []string{},
+			LogLevel:  "error",
+			LogFormat: "text",
+			Color:     false,
+			Envfile:   []string{},
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

Add `--log-format` option to support both human-readable text format and machine-readable JSON format for log output.

## Changes

- Add `LogFormat` field to `Option` struct with default value "text"
- Support `LAMBROLL_LOGFORMAT` environment variable
- Implement format switching logic in CLI initialization:
  - `text` (default): Human-readable format using sloghandler
  - `json`: Machine-readable JSON format using slog.NewJSONHandler
- Update test cases to handle the new LogFormat field

## Usage

```bash
# Human-readable text format (default)
lambroll deploy --log-format=text

# Machine-readable JSON format
lambroll deploy --log-format=json

# Or use environment variable
export LAMBROLL_LOGFORMAT=json
lambroll deploy
```

## Example Output

**Text format:**
```
2025-11-02T12:15:40.250+09:00 [INFO] loading Function
```

**JSON format:**
```json
{"time":"2025-11-02T12:15:42.182740451+09:00","level":"INFO","msg":"loading Function","path":"function.json"}
```

## Benefits

- Better integration with log aggregation tools that prefer JSON format
- Human-friendly output for local development and debugging
- Backward compatible (defaults to text format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)