### PR TITLE
add readme for s3 endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,6 +950,10 @@ local second_tfstate = std.native('my_second_tfstate');
 }
 ```
 
+#### Specify an S3 endpoint for tfstate
+
+When your terraform.tfstate is stored in an S3-compatible storage service, you can specify the S3 endpoint by setting the `AWS_ENDPOINT_URL_S3` environment variable. This spec is based on the [tfstate-lookup](https://github.com/fujiwara/tfstate-lookup?tab=readme-ov-file#s3-endpoint-url-support).
+
 ### .lambdaignore
 
 lambroll will ignore files defined in `.lambdaignore` file at creating a zip archive.


### PR DESCRIPTION
This pull request adds documentation to clarify how to specify a custom S3 endpoint for Terraform state files stored in S3-compatible storage. The new section explains the use of the `AWS_ENDPOINT_URL_S3` environment variable and references the relevant upstream specification.

Documentation updates:

* Added a section to `README.md` describing how to set the `AWS_ENDPOINT_URL_S3` environment variable to specify an S3 endpoint for `terraform.tfstate` stored in S3-compatible services, referencing the `tfstate-lookup` spec.