### PR TITLE
Fix ext_str/ext_code from option file being overridden by CLI args

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -117,8 +117,10 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 	kongOpts := []kong.Option{kong.Vars{"version": Version}}
 
 	// load default options
+	var defaultOpt *Option
 	if optionFilePath != "" {
-		defaultOpt, err := loadDefinitionFile[Option](nil, optionFilePath, nil)
+		var err error
+		defaultOpt, err = loadDefinitionFile[Option](nil, optionFilePath, nil)
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("failed to load option file: %w", err)
 		}
@@ -147,6 +149,17 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 		return "", nil, nil, fmt.Errorf("failed to parse args: %w", err)
 	}
 	opts.Envfile = lo.Uniq(envfiles) // envfiles are parsed before, so it's safe to overwrite
+
+	// Merge ext_str and ext_code from option file with CLI args
+	// CLI args take precedence over option file values
+	if defaultOpt != nil {
+		if defaultOpt.ExtStr != nil || opts.ExtStr != nil {
+			opts.ExtStr = lo.Assign(defaultOpt.ExtStr, opts.ExtStr)
+		}
+		if defaultOpt.ExtCode != nil || opts.ExtCode != nil {
+			opts.ExtCode = lo.Assign(defaultOpt.ExtCode, opts.ExtCode)
+		}
+	}
 
 	sub := strings.Fields(c.Command())[0]
 	return sub, &opts, func() { c.PrintUsage(true) }, nil

--- a/cli_test.go
+++ b/cli_test.go
@@ -195,6 +195,32 @@ var cliTests = []struct {
 			},
 		},
 	},
+	{
+		// Test: CLI args are merged with option file, CLI takes precedence
+		args: []string{
+			"render", "--option", "ext_vars.jsonnet",
+			"--ext-str", "cli_key=cli_val",
+			"--ext-str", "architecture=arm64",
+			"--ext-code", "memory_size=256",
+			"--ext-code", "storage_size=1024",
+		},
+		sub: "render",
+		option: &lambroll.Option{
+			OptionFilePath: "ext_vars.jsonnet",
+			Color:          true,
+			Envfile:        []string{},
+			ExtStr: map[string]string{
+				"architecture": "arm64",                                   // CLI overrides option file (x86_64 -> arm64)
+				"description":  "Test function with ext_str and ext_code", // from option file
+				"cli_key":      "cli_val",                                 // from CLI
+			},
+			ExtCode: map[string]string{
+				"memory_size":  "256",  // CLI overrides option file (128 -> 256)
+				"storage_size": "1024", // CLI overrides option file (512 -> 1024)
+				"timeout":      "30",   // from option file
+			},
+		},
+	},
 }
 
 func TestParseCLI(t *testing.T) {


### PR DESCRIPTION
## Summary

- When `--ext-str` or `--ext-code` flags are specified on the CLI, values defined in the option file were completely replaced instead of being merged.
- This fix merges option file values as the base with CLI args, where CLI args take precedence for duplicate keys.

## Test plan

- [x] Existing `TestParseCLI` tests pass (option file only, CLI only)
- [x] New test case: CLI `--ext-str`/`--ext-code` merged with option file values
- [x] New test case: CLI args override option file values for duplicate keys
- [x] Verified `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)