### PR TITLE
Add DurableConfig to diff/update handling

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -206,6 +206,7 @@ func (app *App) deployFunctionConfiguration(ctx context.Context, fn *Function, o
 		KMSKeyArn:         fn.KMSKeyArn,
 		Layers:            fn.Layers,
 		LoggingConfig:     fn.LoggingConfig,
+		DurableConfig:     fn.DurableConfig,
 		MemorySize:        fn.MemorySize,
 		Role:              fn.Role,
 		Runtime:           fn.Runtime,

--- a/function_test.go
+++ b/function_test.go
@@ -149,7 +149,7 @@ func TestNewFunctionWithDurableConfig(t *testing.T) {
 		Runtime:      types.RuntimePython312,
 		Timeout:      aws.Int32(3),
 		Handler:      aws.String("index.handler"),
-		Role:         aws.String("arn:aws:iam::0123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
+		Role:         aws.String("arn:aws:iam::123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
 		DurableConfig: &types.DurableConfig{
 			ExecutionTimeout:      aws.Int32(900),
 			RetentionPeriodInDays: aws.Int32(14),
@@ -163,7 +163,7 @@ func TestNewFunctionWithDurableConfig(t *testing.T) {
 		Runtime:      types.RuntimePython312,
 		Timeout:      aws.Int32(3),
 		Handler:      aws.String("index.handler"),
-		Role:         aws.String("arn:aws:iam::0123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
+		Role:         aws.String("arn:aws:iam::123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
 		DurableConfig: &types.DurableConfig{
 			ExecutionTimeout:      aws.Int32(900),
 			RetentionPeriodInDays: aws.Int32(14),

--- a/function_test.go
+++ b/function_test.go
@@ -141,3 +141,38 @@ func TestNewFunction(t *testing.T) {
 		t.Errorf("unexpected function got %s", diff)
 	}
 }
+
+func TestNewFunctionWithDurableConfig(t *testing.T) {
+	conf := &types.FunctionConfiguration{
+		FunctionName: aws.String("hello"),
+		MemorySize:   aws.Int32(128),
+		Runtime:      types.RuntimePython312,
+		Timeout:      aws.Int32(3),
+		Handler:      aws.String("index.handler"),
+		Role:         aws.String("arn:aws:iam::0123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
+		DurableConfig: &types.DurableConfig{
+			ExecutionTimeout:      aws.Int32(900),
+			RetentionPeriodInDays: aws.Int32(14),
+		},
+	}
+	fn := lambroll.NewFunctionFrom(conf, nil, nil)
+
+	expected := lambroll.Function{
+		FunctionName: aws.String("hello"),
+		MemorySize:   aws.Int32(128),
+		Runtime:      types.RuntimePython312,
+		Timeout:      aws.Int32(3),
+		Handler:      aws.String("index.handler"),
+		Role:         aws.String("arn:aws:iam::0123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
+		DurableConfig: &types.DurableConfig{
+			ExecutionTimeout:      aws.Int32(900),
+			RetentionPeriodInDays: aws.Int32(14),
+		},
+	}
+
+	fnJSON, _ := lambroll.MarshalJSON(fn)
+	expectedJSON, _ := lambroll.MarshalJSON(expected)
+	if diff := cmp.Diff(string(expectedJSON), string(fnJSON), ignore); diff != "" {
+		t.Errorf("unexpected function got %s", diff)
+	}
+}

--- a/lambroll.go
+++ b/lambroll.go
@@ -315,6 +315,7 @@ func newFunctionFrom(c *types.FunctionConfiguration, code *types.FunctionCodeLoc
 		FunctionName:      c.FunctionName,
 		Handler:           c.Handler,
 		LoggingConfig:     c.LoggingConfig,
+		DurableConfig:     c.DurableConfig,
 		MemorySize:        c.MemorySize,
 		Role:              c.Role,
 		Runtime:           c.Runtime,


### PR DESCRIPTION
## Summary

`DurableConfig` (used by Lambda Durable Execution) was missing from `lambroll`'s diff/update handling:

- `newFunctionFrom` did not copy `DurableConfig` from the AWS SDK response, so `lambroll diff` always reported `+ DurableConfig: {...}` as a new addition, even when the live function already had the matching `DurableConfig` applied.
- `deployFunctionConfiguration` did not pass `DurableConfig` to `UpdateFunctionConfigurationInput`, so subsequent updates would silently reset the field on the live function.

This PR adds `DurableConfig` in both code paths so that diff output is accurate and updates round-trip cleanly.

## Reproduction (before this PR)

1. Deploy a function with `DurableConfig` set in `function.json`:
   ```json
   "DurableConfig": {
     "ExecutionTimeout": 900,
     "RetentionPeriodInDays": 14
   }
   ```
2. Confirm via `aws lambda get-function-configuration` that the live function has the expected `DurableConfig`.
3. Run `lambroll diff` against the same `function.json`:
   ```diff
   +  "DurableConfig": {
   +    "ExecutionTimeout": 900,
   +    "RetentionPeriodInDays": 14
   +  },
   ```
   This `+` block appears on every run even though no change is needed.

## Test plan

- [x] Added `TestNewFunctionWithDurableConfig` covering the SDK → internal `Function` round-trip
- [x] Verified locally with `docker run --rm -e TZ=Asia/Tokyo -v $(pwd):/app -w /app golang:1.26 sh -c "go mod download && go test -race ./..."` — all existing tests plus the new one pass
- [x] Manual verification on a real Lambda whose live `DurableConfig` already matches `function.json`: with the patch applied, `lambroll diff` no longer reports a phantom `+ DurableConfig` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)