### PR TITLE
Exclude GCS and AzureRM tfstate backends from release binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,11 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/lambroll
     binary: lambroll
+    # tfstate-lookup build tags: exclude GCS and AzureRM remote backends.
+    # lambroll only supports the S3 and Terraform Cloud (remote) backends.
+    tags:
+      - no_gcs
+      - no_azurerm
     ldflags:
       - -s -w
     goos:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .PHONY: test binary install clean dist
+
+# tfstate-lookup build tags: exclude GCS and AzureRM remote backends.
+# lambroll only supports the S3 and Terraform Cloud (remote) backends.
+GO_BUILD_TAGS := no_gcs,no_azurerm
+
 cmd/lambroll/lambroll: *.go cmd/lambroll/*.go go.mod go.sum
-	cd cmd/lambroll && go build -ldflags "-s -w" -gcflags="-trimpath=${PWD}"
+	cd cmd/lambroll && go build -tags "$(GO_BUILD_TAGS)" -ldflags "-s -w" -gcflags="-trimpath=${PWD}"
 
 install: cmd/lambroll/lambroll
 	install cmd/lambroll/lambroll ${GOPATH}/bin

--- a/README.md
+++ b/README.md
@@ -957,6 +957,27 @@ local second_tfstate = std.native('my_second_tfstate');
 
 When your terraform.tfstate is stored in an S3-compatible storage service, you can specify the S3 endpoint by setting the `AWS_ENDPOINT_URL_S3` environment variable. This spec is based on the [tfstate-lookup](https://github.com/fujiwara/tfstate-lookup?tab=readme-ov-file#s3-endpoint-url-support).
 
+#### Supported tfstate backends
+
+lambroll uses [tfstate-lookup](https://github.com/fujiwara/tfstate-lookup) to read terraform.tfstate. The following backends are supported by the library:
+
+- Local file
+- HTTP
+- Amazon S3 (`s3://`)
+- Terraform Cloud / Enterprise (`remote` backend)
+- Google Cloud Storage (`gcs`)
+- Azure Blob Storage (`azurerm`)
+
+To keep the binary small, **the official release binaries are built with the `no_gcs` and `no_azurerm` build tags, so the GCS and AzureRM backends are not included.** This applies to all distributed binaries (GitHub Releases, Homebrew, aqua, the GitHub Action, and the CircleCI orb). Using one of these backends with a release binary results in an error such as `GCS backend is not available (built with no_gcs tag)`.
+
+If you need the GCS or AzureRM backend, build lambroll from source without those build tags:
+
+```console
+$ go install github.com/fujiwara/lambroll/cmd/lambroll@latest
+```
+
+`go install` does not apply the `no_gcs` / `no_azurerm` tags, so all backends are available in a binary built this way.
+
 ### .lambdaignore
 
 lambroll will ignore files defined in `.lambdaignore` file at creating a zip archive.


### PR DESCRIPTION
## What

Build the distributed binaries with the `no_gcs` and `no_azurerm` build tags provided by [tfstate-lookup](https://github.com/fujiwara/tfstate-lookup), excluding the GCS and AzureRM remote backends.

- `Makefile`: add `GO_BUILD_TAGS := no_gcs,no_azurerm` and pass it to `go build`.
- `.goreleaser.yml`: add the same tags to the release build.
- `README.md`: document the supported tfstate backends, note that release binaries exclude GCS/AzureRM, and explain how to build from source (`go install`) when those backends are needed.

## Why

lambroll only needs the S3 and Terraform Cloud (`remote`) backends in practice. Dropping the GCS and Azure SDK dependencies from the linked binary keeps the release artifacts smaller. Users who need GCS or AzureRM can still build from source without the tags.