### PR TITLE
fix: sort VPC subnet/security group IDs in diff

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/aereal/jsondiff"
@@ -107,6 +108,11 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 	}
 	remoteFunc := newFunctionFrom(remote, code, tags)
 	fillDefaultValues(remoteFunc)
+
+	// AWS returns VPC subnet/security group IDs in an arbitrary order, so
+	// normalize the ordering on both sides to avoid a spurious diff.
+	sortFunctionForDiff(fn)
+	sortFunctionForDiff(remoteFunc)
 
 	opts := []jsondiff.Option{}
 	if ignore := opt.Ignore; ignore != "" {
@@ -243,6 +249,20 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 	}
 
 	return hasDiff, nil
+}
+
+// sortFunctionForDiff normalizes order-insensitive slice fields so that
+// differences in ordering alone do not produce a spurious diff. AWS treats
+// VPC subnet IDs and security group IDs as sets and may return them in an
+// arbitrary order.
+func sortFunctionForDiff(fn *Function) {
+	if fn == nil {
+		return
+	}
+	if v := fn.VpcConfig; v != nil {
+		sort.Strings(v.SubnetIds)
+		sort.Strings(v.SecurityGroupIds)
+	}
 }
 
 func coloredDiff(src string) string {

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,0 +1,46 @@
+package lambroll_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/fujiwara/lambroll"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSortFunctionForDiff(t *testing.T) {
+	fn := &lambroll.Function{
+		VpcConfig: &types.VpcConfig{
+			SubnetIds: []string{
+				"subnet-08dc9a51660120991",
+				"subnet-023e96b860485e2ad",
+				"subnet-045cd24ab8e92a20d",
+			},
+			SecurityGroupIds: []string{
+				"sg-99999999",
+				"sg-11111111",
+			},
+		},
+	}
+	lambroll.SortFunctionForDiff(fn)
+
+	wantSubnets := []string{
+		"subnet-023e96b860485e2ad",
+		"subnet-045cd24ab8e92a20d",
+		"subnet-08dc9a51660120991",
+	}
+	if diff := cmp.Diff(wantSubnets, fn.VpcConfig.SubnetIds); diff != "" {
+		t.Errorf("subnet ids not sorted (-want +got):\n%s", diff)
+	}
+
+	wantSGs := []string{"sg-11111111", "sg-99999999"}
+	if diff := cmp.Diff(wantSGs, fn.VpcConfig.SecurityGroupIds); diff != "" {
+		t.Errorf("security group ids not sorted (-want +got):\n%s", diff)
+	}
+}
+
+func TestSortFunctionForDiffNil(t *testing.T) {
+	// must not panic on nil function or nil VpcConfig
+	lambroll.SortFunctionForDiff(nil)
+	lambroll.SortFunctionForDiff(&lambroll.Function{})
+}

--- a/export_test.go
+++ b/export_test.go
@@ -14,6 +14,7 @@ var (
 	JSONStr                 = jsonStr
 	MarshalJSON             = marshalJSON
 	NewFunctionFrom         = newFunctionFrom
+	SortFunctionForDiff     = sortFunctionForDiff
 	NewCallerIdentity       = newCallerIdentity
 	Unzip                   = unzip
 	ExtractExitCodeAndError = extractExitCodeAndError


### PR DESCRIPTION
## Problem

`lambroll diff` shows a spurious diff for `VpcConfig` when the subnet IDs (or security group IDs) returned by AWS happen to be in a different order than they are declared in the function definition. AWS treats these as sets and returns them in an arbitrary order, so the diff is noisy and can change run to run even when nothing actually changed.

## Fix

Normalize the ordering of `VpcConfig.SubnetIds` and `VpcConfig.SecurityGroupIds` (lexicographic sort) on **both** the local and remote sides before computing the diff, so order-only differences no longer produce a diff.

This mirrors how [ecspresso](https://github.com/kayac/ecspresso) already handles `awsvpcConfiguration` subnets/security groups in its `ServiceDefinitionForDiff` normalization. (https://github.com/kayac/ecspresso/blob/faae20ddbba25e33e5b459ffd89773bc3a9a79eb/diff.go#L359, https://github.com/kayac/ecspresso/blob/faae20ddbba25e33e5b459ffd89773bc3a9a79eb/diff.go#L454)

Notes:
- The sort is applied only in the diff path (`diffFunction`), not in `fillDefaultValues`, so the deploy path is unchanged — the order sent to AWS on update still follows the definition file. Order is irrelevant to AWS for these fields anyway.
- A genuine add/remove of a subnet or security group still shows up in the diff as expected.

## Test

Added `TestSortFunctionForDiff` (sorting) and `TestSortFunctionForDiffNil` (nil-safety). `go test ./...`, `go vet ./...`, and `gofmt` are all clean.
