### PR TITLE
Add diff --external and unify diff with jsondiff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ make clean
 
 ## Git Workflow
 
+- **The default branch is `v1`** - base feature branches on `v1` and open PRs against it. The `main` branch is outdated; do not use it as a base or diff target.
 - **Never commit directly to main/master/v1 branches** - always create a feature branch first
 - Use `git add <specific-files>` instead of `git add -A` to avoid committing unrelated changes
 - Run `go fmt ./...` before committing Go code

--- a/README.md
+++ b/README.md
@@ -539,6 +539,18 @@ $ lambroll diff --exit-code   # Exit with code 2 if differences exist
 
 Use `--ignore` with jq query syntax to ignore specific fields when comparing.
 
+`lambroll diff --external` can render the diff with an external command of your choice. lambroll writes the remote and local definitions to temporary files and invokes the command with those two file paths as the last two arguments. The fields removed by `--ignore` are also removed from the files passed to the external command.
+
+For example, use [difftastic](https://github.com/Wilfred/difftastic) (`difft`).
+
+```console
+$ lambroll diff --external "difft --color=always"
+
+$ LAMBROLL_DIFF_COMMAND="difft --color=always" lambroll diff
+```
+
+The command must exit with status 0. If it exits with a non-zero status when the two files differ (for example, `diff(1)`), you need to write a wrapper command.
+
 #### Status
 
 ```console

--- a/diff.go
+++ b/diff.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aereal/jsondiff"
 	"github.com/fatih/color"
 	"github.com/itchyny/gojq"
-	"github.com/kylelemons/godebug/diff"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -156,12 +155,16 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 			return false, err
 		}
 		newCodeSha256 := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
 		prefix := "CodeSha256: "
-		if ds := diff.Diff(prefix+currentCodeSha256, prefix+newCodeSha256); ds != "" {
-			fmt.Println(color.RedString("---" + app.functionArn(ctx, name)))
-			fmt.Println(color.GreenString("+++" + "--src=" + opt.Src))
-			fmt.Println(coloredDiff(ds))
+		if diff, err := jsondiff.Diff(
+			&jsondiff.Input{Name: remoteArn, X: prefix + currentCodeSha256},
+			&jsondiff.Input{Name: "--src=" + opt.Src, X: prefix + newCodeSha256},
+		); err != nil {
+			return false, fmt.Errorf("failed to diff: %w", err)
+		} else if diff != "" {
 			hasDiff = true
+			fmt.Print(coloredDiff(diff))
 		}
 	}
 	return hasDiff, nil
@@ -231,21 +234,23 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 	if err != nil {
 		return hasDiff, err
 	}
-	var addsB []byte
+	var addsB []*lambda.AddPermissionInput
 	for _, in := range adds {
-		b, _ := marshalJSON(in)
-		addsB = append(addsB, b...)
+		addsB = append(addsB, in)
 	}
-	var removesB []byte
+	var removesB []*lambda.AddPermissionInput
 	for _, in := range removes {
-		b, _ := marshalJSON(in)
-		removesB = append(removesB, b...)
+		removesB = append(removesB, in)
 	}
-	if ds := diff.Diff(string(removesB), string(addsB)); ds != "" {
-		fmt.Println(color.RedString("--- permissions"))
-		fmt.Println(color.GreenString("+++ permissions"))
-		fmt.Print(coloredDiff(ds))
+
+	if diff, err := jsondiff.Diff(
+		&jsondiff.Input{Name: "permissions", X: removesB},
+		&jsondiff.Input{Name: "permissions", X: addsB},
+	); err != nil {
+		return hasDiff, fmt.Errorf("failed to diff: %w", err)
+	} else if diff != "" {
 		hasDiff = true
+		fmt.Print(coloredDiff(diff))
 	}
 
 	return hasDiff, nil

--- a/diff.go
+++ b/diff.go
@@ -4,16 +4,21 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/aereal/jsondiff"
 	"github.com/fatih/color"
 	"github.com/itchyny/gojq"
+	"github.com/mattn/go-shellwords"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -29,14 +34,20 @@ type DiffOption struct {
 	Ignore       string  `help:"ignore diff by jq query" default:""`
 	ExitCode     bool    `help:"exit with code 2 if there are differences" default:"false"`
 	SkipFunction bool    `help:"skip function diff. shows function-url only" default:"false"`
+	External     string  `help:"external command to display diff" default:"" env:"LAMBROLL_DIFF_COMMAND"`
 
 	ZipOption
+
+	w io.Writer `kong:"-"`
 }
 
 // Diff prints diff of function.json compared with latest function
 func (app *App) Diff(ctx context.Context, opt *DiffOption) error {
 	if err := opt.Expand(); err != nil {
 		return err
+	}
+	if opt.w == nil {
+		opt.w = os.Stdout
 	}
 	fn, err := app.loadFunction(app.functionFilePath)
 	if err != nil {
@@ -113,29 +124,19 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 	sortFunctionForDiff(fn)
 	sortFunctionForDiff(remoteFunc)
 
-	opts := []jsondiff.Option{}
-	if ignore := opt.Ignore; ignore != "" {
-		if p, err := gojq.Parse(ignore); err != nil {
-			return false, fmt.Errorf("failed to parse ignore query: %s %w", ignore, err)
-		} else {
-			opts = append(opts, jsondiff.Ignore(p))
-		}
-	}
-
 	remoteJSON, _ := marshalAny(remoteFunc)
 	newJSON, _ := marshalAny(fn)
 	remoteArn := fullQualifiedFunctionName(app.functionArn(ctx, name), opt.Qualifier)
 	hasDiff := false
 
-	if diff, err := jsondiff.Diff(
+	if d, err := app.emitDiff(ctx, opt, "function.json",
 		&jsondiff.Input{Name: remoteArn, X: remoteJSON},
 		&jsondiff.Input{Name: app.functionFilePath, X: newJSON},
-		opts...,
+		opt.Ignore,
 	); err != nil {
-		return false, fmt.Errorf("failed to diff: %w", err)
-	} else if diff != "" {
+		return false, err
+	} else if d {
 		hasDiff = true
-		fmt.Print(coloredDiff(diff))
 	}
 
 	if err := validateUpdateFunction(remote, code, fn); err != nil {
@@ -157,14 +158,14 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 		newCodeSha256 := base64.StdEncoding.EncodeToString(h.Sum(nil))
 
 		prefix := "CodeSha256: "
-		if diff, err := jsondiff.Diff(
+		if d, err := app.emitDiff(ctx, opt, "CodeSha256.txt",
 			&jsondiff.Input{Name: remoteArn, X: prefix + currentCodeSha256},
 			&jsondiff.Input{Name: "--src=" + opt.Src, X: prefix + newCodeSha256},
+			"",
 		); err != nil {
-			return false, fmt.Errorf("failed to diff: %w", err)
-		} else if diff != "" {
+			return false, err
+		} else if d {
 			hasDiff = true
-			fmt.Print(coloredDiff(diff))
 		}
 	}
 	return hasDiff, nil
@@ -219,14 +220,14 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 	r, _ := toGeneralMap(remote, true)
 	l, _ := toGeneralMap(local, true)
 
-	if diff, err := jsondiff.Diff(
+	if d, err := app.emitDiff(ctx, opt, "function_url.json",
 		&jsondiff.Input{Name: fqName, X: r},
 		&jsondiff.Input{Name: opt.FunctionURL, X: l},
+		"",
 	); err != nil {
-		return hasDiff, fmt.Errorf("failed to diff: %w", err)
-	} else if diff != "" {
+		return hasDiff, err
+	} else if d {
 		hasDiff = true
-		fmt.Print(coloredDiff(diff))
 	}
 
 	// permissions
@@ -243,14 +244,14 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 		removesB = append(removesB, in)
 	}
 
-	if diff, err := jsondiff.Diff(
+	if d, err := app.emitDiff(ctx, opt, "permissions.json",
 		&jsondiff.Input{Name: "permissions", X: removesB},
 		&jsondiff.Input{Name: "permissions", X: addsB},
+		"",
 	); err != nil {
-		return hasDiff, fmt.Errorf("failed to diff: %w", err)
-	} else if diff != "" {
+		return hasDiff, err
+	} else if d {
 		hasDiff = true
-		fmt.Print(coloredDiff(diff))
 	}
 
 	return hasDiff, nil
@@ -268,6 +269,125 @@ func sortFunctionForDiff(fn *Function) {
 		sort.Strings(v.SubnetIds)
 		sort.Strings(v.SecurityGroupIds)
 	}
+}
+
+// emitDiff computes the diff between from and to using jsondiff (honoring the
+// ignore jq query) and renders it. When opt.External is set, the diff is shown
+// by running the external command against two temporary files instead of the
+// built-in colored unified diff. It returns true if there is any difference.
+func (app *App) emitDiff(ctx context.Context, opt *DiffOption, label string, from, to *jsondiff.Input, ignore string) (bool, error) {
+	var jsonOpts []jsondiff.Option
+	if ignore != "" {
+		p, err := gojq.Parse(ignore)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse ignore query: %s %w", ignore, err)
+		}
+		jsonOpts = append(jsonOpts, jsondiff.Ignore(p))
+	}
+
+	diff, err := jsondiff.Diff(from, to, jsonOpts...)
+	if err != nil {
+		return false, fmt.Errorf("failed to diff: %w", err)
+	}
+	if diff == "" {
+		return false, nil
+	}
+
+	if opt.External != "" {
+		remote, err := renderForExternalDiff(from.X, ignore)
+		if err != nil {
+			return false, err
+		}
+		local, err := renderForExternalDiff(to.X, ignore)
+		if err != nil {
+			return false, err
+		}
+		if err := runExternalDiff(ctx, opt.External, label, remote, local, opt.w); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	fmt.Fprint(opt.w, coloredDiff(diff))
+	return true, nil
+}
+
+// renderForExternalDiff converts a diff input value into the text written to a
+// temporary file for the external diff command. When an ignore query is given,
+// the same fields ignored by jsondiff are deleted here too, so that the
+// external diff does not display ignored differences.
+func renderForExternalDiff(x any, ignore string) (string, error) {
+	if ignore != "" {
+		q, err := gojq.Parse("del(" + ignore + ")")
+		if err != nil {
+			return "", fmt.Errorf("failed to parse ignore query: %s %w", ignore, err)
+		}
+		modified, err := jsondiff.ModifyValue(q, x)
+		if err != nil {
+			return "", fmt.Errorf("failed to apply ignore query: %w", err)
+		}
+		x = modified
+	}
+	if s, ok := x.(string); ok {
+		return s, nil
+	}
+	b, err := json.MarshalIndent(x, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal for external diff: %w", err)
+	}
+	return string(b) + "\n", nil
+}
+
+// runExternalDiff writes the remote and local content into temporary files and
+// runs the external command with the two file paths appended as arguments.
+// The command's stdout is written to w. The command must exit with status 0;
+// wrap commands such as diff(1) that exit non-zero on differences.
+func runExternalDiff(ctx context.Context, command, label, remote, local string, w io.Writer) error {
+	args, err := shellwords.Parse(command)
+	if err != nil {
+		return fmt.Errorf("failed to parse diff command %q: %w", command, err)
+	}
+	if len(args) == 0 {
+		return fmt.Errorf("empty diff command")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "lambroll-diff-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current dir: %w", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		return fmt.Errorf("failed to chdir: %w", err)
+	}
+	defer os.Chdir(pwd)
+
+	for _, name := range []string{"remote", "local"} {
+		if err := os.Mkdir(name, 0755); err != nil {
+			return fmt.Errorf("failed to create %s dir: %w", name, err)
+		}
+	}
+	remoteFile := filepath.Join("remote", label)
+	localFile := filepath.Join("local", label)
+	if err := os.WriteFile(remoteFile, []byte(remote), 0644); err != nil {
+		return fmt.Errorf("failed to write remote file: %w", err)
+	}
+	if err := os.WriteFile(localFile, []byte(local), 0644); err != nil {
+		return fmt.Errorf("failed to write local file: %w", err)
+	}
+	args = append(args, remoteFile, localFile)
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stdout = w
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run diff command: %w", err)
+	}
+	return nil
 }
 
 func coloredDiff(src string) string {

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,6 +1,9 @@
 package lambroll_test
 
 import (
+	"bytes"
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
@@ -43,4 +46,75 @@ func TestSortFunctionForDiffNil(t *testing.T) {
 	// must not panic on nil function or nil VpcConfig
 	lambroll.SortFunctionForDiff(nil)
 	lambroll.SortFunctionForDiff(&lambroll.Function{})
+}
+
+func TestRunExternalDiff(t *testing.T) {
+	// "cat" concatenates the remote and local files passed as the last two args,
+	// so the writer must contain both contents in order.
+	var buf bytes.Buffer
+	err := lambroll.RunExternalDiff(
+		context.Background(),
+		"cat",
+		"function.json",
+		"remote-content\n",
+		"local-content\n",
+		&buf,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := buf.String(); got != "remote-content\nlocal-content\n" {
+		t.Errorf("unexpected output: %q", got)
+	}
+}
+
+func TestRunExternalDiffCommandError(t *testing.T) {
+	var buf bytes.Buffer
+	err := lambroll.RunExternalDiff(
+		context.Background(),
+		"this-command-should-not-exist-xyz",
+		"function.json",
+		"a", "b",
+		&buf,
+	)
+	if err == nil {
+		t.Error("expected an error for a non-existent command, got nil")
+	}
+}
+
+func TestRenderForExternalDiff(t *testing.T) {
+	t.Run("string passes through", func(t *testing.T) {
+		got, err := lambroll.RenderForExternalDiff("CodeSha256: abc", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "CodeSha256: abc" {
+			t.Errorf("unexpected: %q", got)
+		}
+	})
+
+	t.Run("map marshaled as indented json", func(t *testing.T) {
+		got, err := lambroll.RenderForExternalDiff(map[string]any{"a": "b"}, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "{\n  \"a\": \"b\"\n}\n"
+		if got != want {
+			t.Errorf("unexpected: %q want %q", got, want)
+		}
+	})
+
+	t.Run("ignore query deletes fields", func(t *testing.T) {
+		in := map[string]any{"Keep": "yes", "Drop": "no"}
+		got, err := lambroll.RenderForExternalDiff(in, ".Drop")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(got, "Drop") {
+			t.Errorf("ignored field should be removed: %q", got)
+		}
+		if !strings.Contains(got, "Keep") {
+			t.Errorf("kept field should remain: %q", got)
+		}
+	})
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,7 @@
 package lambroll
 
 import (
+	"io"
 	"os"
 	"sync"
 )
@@ -19,7 +20,13 @@ var (
 	Unzip                   = unzip
 	ExtractExitCodeAndError = extractExitCodeAndError
 	IsAWSManagedTag         = isAWSManagedTag
+	RunExternalDiff         = runExternalDiff
+	RenderForExternalDiff   = renderForExternalDiff
 )
+
+func (o *DiffOption) SetWriter(w io.Writer) {
+	o.w = w
+}
 
 type VersionsOutput = versionsOutput
 type VersionsOutputs = versionsOutputs

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	golang.org/x/sys v0.42.0
 )
 
+require github.com/mattn/go-shellwords v1.0.13
+
 require (
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.123.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,13 +24,12 @@ require (
 	github.com/kayac/go-config v0.7.0
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-shellwords v1.0.13
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/samber/lo v1.52.0
 	github.com/shogo82148/go-retry v1.3.1
 	golang.org/x/sys v0.42.0
 )
-
-require github.com/mattn/go-shellwords v1.0.13
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/itchyny/gojq v0.12.19
 	github.com/kayac/go-config v0.7.0
-	github.com/kylelemons/godebug v1.1.0
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/samber/lo v1.52.0

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-shellwords v1.0.13 h1:DC0OMEpGjm6LfNFU4ckYcvbQKyp2vE8atyFGXNtDcf4=
+github.com/mattn/go-shellwords v1.0.13/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=


### PR DESCRIPTION
## What

- Unify all diff processes (code SHA256 / function-url permissions) on `jsondiff` instead of `kylelemons/godebug/diff`.
- Add `diff --external "<command>"` (env `LAMBROLL_DIFF_COMMAND`) to render the diff with an external command such as [difftastic](https://github.com/Wilfred/difftastic).

## Why

A single diff backend keeps output consistent and lets users plug in their preferred diff viewer. lambroll writes the remote and local definitions to temporary files and runs the command with the two paths. Fields removed by `--ignore` are removed from those files too, so the external diff matches the built-in one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)