### PR TITLE
ci: replace LocalStack with floci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go }}
           cache: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,14 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      localstack:
-        image: localstack/localstack:1.4.0
-        env:
-          SERVICES: lambda,sts,s3
-          DEFAULT_REGION: ap-northeast-1
-          DEBUG: 1
-          LAMBDA_EXECUTOR: local
-          TEST_AWS_ACCOUNT_ID: 123456789012
+      floci:
+        image: floci/floci@sha256:4060e0f8ded3cf0f53bde641ce6b8d2ec8a6355d936cc856ac806cc88dda1a49 # 1.5.21
         ports:
           - 4566:4566
 

--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -19,22 +19,22 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag || github.ref }}
-      - uses: Songmu/tagpr@9bbb945b2fb025126186661e27d55485e3fc6df6 # v1.18.3
+      - uses: Songmu/tagpr@e84001bd5dac8defa0c75b3913937d284a3b3660 # v1.20.0
         id: tagpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name != 'workflow_dispatch' }} # skip on workflow_dispatch
       # after tagpr adds a release tag, or workflow_dispatch, release it
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: '~> v2'
           args: release


### PR DESCRIPTION
## What

- Replace the LocalStack service container in the Go workflow with [floci](https://floci.io/), pinned by image digest (tag `1.5.21` noted in a comment).
- Update other GitHub Actions to their latest pinned versions via `pinact run -u`:
  - `Songmu/tagpr` v1.18.3 → v1.20.0
  - `goreleaser/goreleaser-action` v7 → v7.2.2
  - corrected version comments for `actions/checkout` and `actions/setup-go`

## Why

The CI used an old `localstack/localstack:1.4.0`. floci is a drop-in, MIT-licensed LocalStack replacement on the same port 4566. It starts all services without service selection, so the LocalStack-specific env vars are dropped. The deploy-only test flow (no Lambda invocation) was verified to run against floci without a Docker socket mount.

`action.yml` is intentionally left unchanged: its `fujiwara/lambroll@v1` / `@v1-actions-test` are self-references used to test this action by branch/tag, so they must not be pinned to a SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)