### PR TITLE
Fix minor robustness issues and cleanups

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -235,18 +235,9 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 	if err != nil {
 		return hasDiff, err
 	}
-	var addsB []*lambda.AddPermissionInput
-	for _, in := range adds {
-		addsB = append(addsB, in)
-	}
-	var removesB []*lambda.AddPermissionInput
-	for _, in := range removes {
-		removesB = append(removesB, in)
-	}
-
 	if d, err := app.emitDiff(ctx, opt, "permissions.json",
-		&jsondiff.Input{Name: "permissions", X: removesB},
-		&jsondiff.Input{Name: "permissions", X: addsB},
+		&jsondiff.Input{Name: "permissions", X: removes},
+		&jsondiff.Input{Name: "permissions", X: adds},
 		"",
 	); err != nil {
 		return hasDiff, err

--- a/function_test.go
+++ b/function_test.go
@@ -176,23 +176,3 @@ func TestNewFunctionWithDurableConfig(t *testing.T) {
 		t.Errorf("unexpected function got %s", diff)
 	}
 }
-
-// TestNewFunctionWithNilVpcID ensures NewFunctionFrom does not panic when the
-// VpcConfig is present but VpcId is nil (a function that is not attached to a VPC).
-func TestNewFunctionWithNilVpcID(t *testing.T) {
-	conf := &types.FunctionConfiguration{
-		FunctionName: aws.String("hello"),
-		MemorySize:   aws.Int32(128),
-		Runtime:      types.RuntimeNodejs18x,
-		Timeout:      aws.Int32(3),
-		Handler:      aws.String("index.handler"),
-		Role:         aws.String("arn:aws:iam::123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
-		VpcConfig: &types.VpcConfigResponse{
-			VpcId: nil, // not attached to a VPC
-		},
-	}
-	fn := lambroll.NewFunctionFrom(conf, nil, nil)
-	if fn.VpcConfig != nil {
-		t.Errorf("VpcConfig should be nil when VpcId is empty, got %v", fn.VpcConfig)
-	}
-}

--- a/function_test.go
+++ b/function_test.go
@@ -176,3 +176,23 @@ func TestNewFunctionWithDurableConfig(t *testing.T) {
 		t.Errorf("unexpected function got %s", diff)
 	}
 }
+
+// TestNewFunctionWithNilVpcID ensures NewFunctionFrom does not panic when the
+// VpcConfig is present but VpcId is nil (a function that is not attached to a VPC).
+func TestNewFunctionWithNilVpcID(t *testing.T) {
+	conf := &types.FunctionConfiguration{
+		FunctionName: aws.String("hello"),
+		MemorySize:   aws.Int32(128),
+		Runtime:      types.RuntimeNodejs18x,
+		Timeout:      aws.Int32(3),
+		Handler:      aws.String("index.handler"),
+		Role:         aws.String("arn:aws:iam::123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
+		VpcConfig: &types.VpcConfigResponse{
+			VpcId: nil, // not attached to a VPC
+		},
+	}
+	fn := lambroll.NewFunctionFrom(conf, nil, nil)
+	if fn.VpcConfig != nil {
+		t.Errorf("VpcConfig should be nil when VpcId is empty, got %v", fn.VpcConfig)
+	}
+}

--- a/init.go
+++ b/init.go
@@ -83,7 +83,7 @@ func (app *App) Init(ctx context.Context, opt *InitOption) error {
 	}
 	fn := newFunctionFrom(c, code, tags)
 
-	if (opt.DownloadZip || opt.Unzip) && res.Code != nil && *res.Code.RepositoryType == "S3" {
+	if (opt.DownloadZip || opt.Unzip) && res != nil && res.Code != nil && aws.ToString(res.Code.RepositoryType) == "S3" {
 		slog.Info("downloading file", "file", FunctionZipFilename)
 		if err := download(ctx, *res.Code.Location, FunctionZipFilename); err != nil {
 			return err
@@ -148,8 +148,11 @@ func download(ctx context.Context, url, path string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", path, err)
 	}
-	_, err = io.Copy(f, resp.Body)
-	return err
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", path, err)
+	}
+	return f.Close()
 }
 
 func unzipAfterInit(ctx context.Context, path, dest string, force bool) error {

--- a/lambroll.go
+++ b/lambroll.go
@@ -334,7 +334,7 @@ func newFunctionFrom(c *types.FunctionConfiguration, code *types.FunctionCodeLoc
 			Mode: t.Mode,
 		}
 	}
-	if v := c.VpcConfig; v != nil && *v.VpcId != "" {
+	if v := c.VpcConfig; v != nil && aws.ToString(v.VpcId) != "" {
 		fn.VpcConfig = &types.VpcConfig{
 			SubnetIds:               v.SubnetIds,
 			SecurityGroupIds:        v.SecurityGroupIds,

--- a/tags_test.go
+++ b/tags_test.go
@@ -16,10 +16,6 @@ type tagsTestCase struct {
 	removeKeys keys
 }
 
-func s(s string) *string {
-	return &s
-}
-
 var mergeTagsCase = []tagsTestCase{
 	{
 		oldTags:    tags{"Foo": "FOO", "Bar": "BAR", "Tee": "TEE"},


### PR DESCRIPTION
## What

Small robustness fixes and cleanups found while preparing v1.5:

- **lambroll.go**: guard against a nil `VpcId` when building a `Function` from an existing configuration, avoiding a potential panic in `init`.
- **init.go**: guard nil `res` before dereferencing `res.Code`, and use `aws.ToString` for `RepositoryType` in the download condition.
- **init.go**: close the downloaded file (defer + checked close) to avoid a file descriptor leak and to surface write/close errors.
- **diff.go**: pass the permission slices directly instead of copying them in redundant loops (staticcheck S1011).
- **tags_test.go**: remove the unused helper `func s` (staticcheck U1000).

## Why

These are low-risk correctness and cleanup items worth shipping in the v1.5 minor release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)