### PR TITLE
Add diff --mask to hide sensitive values in diff output

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,9 +535,41 @@ $ lambroll diff --code        # Compare code SHA256
 $ lambroll diff --qualifier current  # Compare with specific version/alias
 $ lambroll diff --ignore='.Environment.Variables.TIMESTAMP'  # Ignore specific fields
 $ lambroll diff --exit-code   # Exit with code 2 if differences exist
+$ lambroll diff --mask=DB_PASSWORD                  # Mask an environment variable value
+$ lambroll diff --mask='.Environment.Variables[]'   # Mask all environment variable values
 ```
 
 Use `--ignore` with jq query syntax to ignore specific fields when comparing.
+
+Use `--mask` to hide sensitive values in the diff output while still showing whether they changed. lambroll resolves template/Jsonnet functions when it loads a function definition, so a secret referenced via `ssm(...)` — for example an SSM `SecureString` parameter used as an environment variable value — is expanded to its decrypted value in the rendered config and would otherwise appear in plaintext in the diff. Unlike `--ignore` (which drops a field from the comparison entirely), `--mask` keeps the field but replaces its value with an opaque per-run token. A `--mask` argument that begins with `.` is used as a jq selector; otherwise it is treated as a Lambda environment variable name and expanded to `.Environment.Variables["<name>"]`. The flag is repeatable.
+
+Equal values share a token (so an unchanged value produces no diff line) and changed values get different tokens, so drift stays visible without revealing the value:
+
+```console
+$ lambroll diff --mask DB_PASSWORD
+   "Environment": {
+     "Variables": {
+-      "DB_PASSWORD": "***MASKED#1***"
++      "DB_PASSWORD": "***MASKED#2***"
+     }
+   }
+```
+
+`--mask '.Environment.Variables'` masks the whole map (hiding the variable names too), while `--mask '.Environment.Variables[]'` masks each value but keeps the names visible. Masking applies only to the function configuration diff (not the code SHA256, function URL, or permissions diffs) and never affects `deploy`.
+
+You can set a default mask list in the [option file](#option-file) under the `diff.mask` key; entries may mix both forms and are combined with any `--mask` flags (CLI values are added, never replacing the configured list):
+
+```jsonnet
+{
+  diff: {
+    mask: [
+      'DB_PASSWORD',
+      'API_KEY',
+      '.Environment.Variables[]',
+    ],
+  },
+}
+```
 
 `lambroll diff --external` can render the diff with an external command of your choice. lambroll writes the remote and local definitions to temporary files and invokes the command with those two file paths as the last two arguments. The fields removed by `--ignore` are also removed from the files passed to the external command.
 

--- a/cli.go
+++ b/cli.go
@@ -30,6 +30,10 @@ type Option struct {
 	Envfile         []string          `help:"environment files" env:"LAMBROLL_ENVFILE" json:"envfile,omitempty"`
 	ExtStr          map[string]string `help:"external string values for Jsonnet" env:"LAMBROLL_EXTSTR" json:"ext_str,omitempty"`
 	ExtCode         map[string]string `help:"external code values for Jsonnet" env:"LAMBROLL_EXTCODE" json:"ext_code,omitempty"`
+
+	// Diff holds option-file config scoped to the diff command (diff.mask).
+	// It is not a CLI flag; ParseCLI merges it into DiffOption.Mask.
+	Diff DiffMaskOption `kong:"-" json:"diff,omitempty"`
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling to support both old and new field names
@@ -158,6 +162,17 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 		if defaultOpt.ExtCode != nil || opts.ExtCode != nil {
 			opts.ExtCode = lo.Assign(defaultOpt.ExtCode, opts.ExtCode)
 		}
+	}
+
+	// Merge option-file diff.mask entries with the CLI --mask values additively
+	// (option-file first, CLI appended) so the mask set never shrinks. kong
+	// allocates opts.Diff for every subcommand; the merged slice is only consumed
+	// by the diff command (dispatchCLI), so writing it elsewhere is harmless.
+	if defaultOpt != nil && opts.Diff != nil && len(defaultOpt.Diff.Mask) > 0 {
+		merged := make([]string, 0, len(defaultOpt.Diff.Mask)+len(opts.Diff.Mask))
+		merged = append(merged, defaultOpt.Diff.Mask...)
+		merged = append(merged, opts.Diff.Mask...)
+		opts.Diff.Mask = merged
 	}
 
 	sub := strings.Fields(c.Command())[0]

--- a/cli_option_test.go
+++ b/cli_option_test.go
@@ -86,3 +86,46 @@ func TestOptionUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionUnmarshalJSONDiffMask(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData string
+		wantMask []string
+		wantExt  map[string]string
+	}{
+		{
+			name:     "diff.mask with mixed forms",
+			jsonData: `{"diff": {"mask": ["DB_PASSWORD", ".Environment.Variables[\"API_KEY\"]"]}}`,
+			wantMask: []string{"DB_PASSWORD", `.Environment.Variables["API_KEY"]`},
+		},
+		{
+			name:     "absent diff key leaves mask nil",
+			jsonData: `{"region": "us-west-2"}`,
+			wantMask: nil,
+		},
+		{
+			name:     "diff.mask coexists with legacy extstr",
+			jsonData: `{"extstr": {"k": "v"}, "diff": {"mask": ["X"]}}`,
+			wantMask: []string{"X"},
+			wantExt:  map[string]string{"k": "v"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got lambroll.Option
+			if err := json.Unmarshal([]byte(tt.jsonData), &got); err != nil {
+				t.Fatalf("UnmarshalJSON error = %v", err)
+			}
+			if diff := cmp.Diff(tt.wantMask, got.Diff.Mask); diff != "" {
+				t.Errorf("Diff.Mask mismatch (-want +got):\n%s", diff)
+			}
+			if tt.wantExt != nil {
+				if diff := cmp.Diff(tt.wantExt, got.ExtStr); diff != "" {
+					t.Errorf("ExtStr back-compat disturbed (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -257,3 +257,75 @@ func TestParseCLI(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCLIDiffMask(t *testing.T) {
+	cwd, _ := os.Getwd()
+	os.Chdir("test/cli")
+	defer os.Chdir(cwd)
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "repeatable --mask, no option file",
+			args: []string{"diff", "--mask", "DB_PASSWORD", "--mask", "API_KEY"},
+			want: []string{"DB_PASSWORD", "API_KEY"},
+		},
+		{
+			name: "option-file diff.mask only",
+			args: []string{"diff", "--option", "diff_mask.jsonnet"},
+			want: []string{"DB_PASSWORD", `.Environment.Variables["API_KEY"]`},
+		},
+		{
+			name: "option-file diff.mask plus CLI --mask, CLI added on top",
+			args: []string{"diff", "--option", "diff_mask.jsonnet", "--mask", "EXTRA"},
+			// option entries first, then CLI added (never replacing)
+			want: []string{"DB_PASSWORD", `.Environment.Variables["API_KEY"]`, "EXTRA"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub, opt, _, err := lambroll.ParseCLI(tt.args)
+			if err != nil {
+				t.Fatalf("ParseCLI error: %v", err)
+			}
+			if sub != "diff" {
+				t.Fatalf("unexpected subcommand: %s", sub)
+			}
+			if opt.Diff == nil {
+				t.Fatal("opt.Diff is nil")
+			}
+			if diff := cmp.Diff(tt.want, opt.Diff.Mask); diff != "" {
+				t.Errorf("DiffOption.Mask mismatch (-want +got):\n%s", diff)
+			}
+			// fail-safe: merged set never shorter than the CLI count alone.
+			if len(opt.Diff.Mask) < len(tt.want) {
+				t.Errorf("merged mask set shrank: got %d want >= %d", len(opt.Diff.Mask), len(tt.want))
+			}
+		})
+	}
+}
+
+func TestParseCLIDiffMaskEffectiveSet(t *testing.T) {
+	cwd, _ := os.Getwd()
+	os.Chdir("test/cli")
+	defer os.Chdir(cwd)
+
+	// CLI passes DB_PASSWORD which is already in the option file; the merged
+	// carried slice has a duplicate, but the effective set dedupes it.
+	_, opt, _, err := lambroll.ParseCLI([]string{"diff", "--option", "diff_mask.jsonnet", "--mask", "DB_PASSWORD"})
+	if err != nil {
+		t.Fatalf("ParseCLI error: %v", err)
+	}
+	effective := lambroll.BuildEffectiveMaskSet(opt.Diff.Mask, nil)
+	want := []string{
+		`.Environment.Variables["DB_PASSWORD"]`,
+		`.Environment.Variables["API_KEY"]`,
+	}
+	if diff := cmp.Diff(want, effective); diff != "" {
+		t.Errorf("effective mask set mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/diff.go
+++ b/diff.go
@@ -36,6 +36,8 @@ type DiffOption struct {
 	SkipFunction bool    `help:"skip function diff. shows function-url only" default:"false"`
 	External     string  `help:"external command to display diff" default:"" env:"LAMBROLL_DIFF_COMMAND"`
 
+	Mask []string `help:"mask values by jq query or environment variable name (repeatable)"`
+
 	ZipOption
 
 	w io.Writer `kong:"-"`
@@ -129,10 +131,15 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 	remoteArn := fullQualifiedFunctionName(app.functionArn(ctx, name), opt.Qualifier)
 	hasDiff := false
 
+	// masking is applied only to the function configuration diff, with a single
+	// registry shared across both sides so equal values collapse to one token.
+	maskSelectors := buildEffectiveMaskSet(opt.Mask, nil)
+	maskReg := newMaskTokenRegistry()
+
 	if d, err := app.emitDiff(ctx, opt, "function.json",
 		&jsondiff.Input{Name: remoteArn, X: remoteJSON},
 		&jsondiff.Input{Name: app.functionFilePath, X: newJSON},
-		opt.Ignore,
+		opt.Ignore, maskSelectors, maskReg,
 	); err != nil {
 		return false, err
 	} else if d {
@@ -161,7 +168,7 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 		if d, err := app.emitDiff(ctx, opt, "CodeSha256.txt",
 			&jsondiff.Input{Name: remoteArn, X: prefix + currentCodeSha256},
 			&jsondiff.Input{Name: "--src=" + opt.Src, X: prefix + newCodeSha256},
-			"",
+			"", nil, nil,
 		); err != nil {
 			return false, err
 		} else if d {
@@ -223,7 +230,7 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 	if d, err := app.emitDiff(ctx, opt, "function_url.json",
 		&jsondiff.Input{Name: fqName, X: r},
 		&jsondiff.Input{Name: opt.FunctionURL, X: l},
-		"",
+		"", nil, nil,
 	); err != nil {
 		return hasDiff, err
 	} else if d {
@@ -238,7 +245,7 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 	if d, err := app.emitDiff(ctx, opt, "permissions.json",
 		&jsondiff.Input{Name: "permissions", X: removes},
 		&jsondiff.Input{Name: "permissions", X: adds},
-		"",
+		"", nil, nil,
 	); err != nil {
 		return hasDiff, err
 	} else if d {
@@ -266,7 +273,26 @@ func sortFunctionForDiff(fn *Function) {
 // ignore jq query) and renders it. When opt.External is set, the diff is shown
 // by running the external command against two temporary files instead of the
 // built-in colored unified diff. It returns true if there is any difference.
-func (app *App) emitDiff(ctx context.Context, opt *DiffOption, label string, from, to *jsondiff.Input, ignore string) (bool, error) {
+//
+// When maskSelectors is non-empty, ignore and then mask are applied to deep
+// copies of from.X / to.X before rendering, so every render path sees only
+// masked values. With no selectors the inputs are untouched.
+func (app *App) emitDiff(ctx context.Context, opt *DiffOption, label string, from, to *jsondiff.Input, ignore string, maskSelectors []string, maskReg *maskTokenRegistry) (bool, error) {
+	if len(maskSelectors) > 0 {
+		fromMasked, err := maskInput(from.X, ignore, maskSelectors, maskReg)
+		if err != nil {
+			return false, err
+		}
+		toMasked, err := maskInput(to.X, ignore, maskSelectors, maskReg)
+		if err != nil {
+			return false, err
+		}
+		from = &jsondiff.Input{Name: from.Name, X: fromMasked}
+		to = &jsondiff.Input{Name: to.Name, X: toMasked}
+		// ignore has already been applied to the masked copies.
+		ignore = ""
+	}
+
 	var jsonOpts []jsondiff.Option
 	if ignore != "" {
 		p, err := gojq.Parse(ignore)

--- a/diff_test.go
+++ b/diff_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aereal/jsondiff"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/fatih/color"
 	"github.com/fujiwara/lambroll"
 	"github.com/google/go-cmp/cmp"
 )
@@ -117,4 +119,229 @@ func TestRenderForExternalDiff(t *testing.T) {
 			t.Errorf("kept field should remain: %q", got)
 		}
 	})
+}
+
+func newFuncConfig(vars map[string]any) map[string]any {
+	return map[string]any{
+		"FunctionName": "test-func",
+		"Environment": map[string]any{
+			"Variables": vars,
+		},
+	}
+}
+
+func runEmitDiff(t *testing.T, from, to map[string]any, ignore string, selectors []string) (string, bool) {
+	t.Helper()
+	app := &lambroll.App{}
+	opt := &lambroll.DiffOption{}
+	var buf bytes.Buffer
+	opt.SetWriter(&buf)
+	reg := lambroll.NewMaskTokenRegistry()
+	d, err := app.EmitDiff(
+		context.Background(), opt, "function.json",
+		&jsondiff.Input{Name: "remote", X: from},
+		&jsondiff.Input{Name: "local", X: to},
+		ignore, selectors, reg,
+	)
+	if err != nil {
+		t.Fatalf("emitDiff error: %v", err)
+	}
+	return buf.String(), d
+}
+
+func TestEmitDiffMaskBuiltin(t *testing.T) {
+	const oldSecret = "old-secret-value"
+	const newSecret = "new-secret-value"
+
+	t.Run("changed value renders as differing tokens, drift visible", func(t *testing.T) {
+		from := newFuncConfig(map[string]any{"DB_PASSWORD": oldSecret})
+		to := newFuncConfig(map[string]any{"DB_PASSWORD": newSecret})
+		out, hasDiff := runEmitDiff(t, from, to, "", []string{`.Environment.Variables["DB_PASSWORD"]`})
+		if !hasDiff {
+			t.Fatal("expected a difference for changed value")
+		}
+		if strings.Contains(out, oldSecret) || strings.Contains(out, newSecret) {
+			t.Errorf("raw value leaked into built-in diff:\n%s", out)
+		}
+		if !strings.Contains(out, "***MASKED#") {
+			t.Errorf("expected a mask token in diff output:\n%s", out)
+		}
+		// two distinct values -> two distinct tokens
+		if !strings.Contains(out, "***MASKED#1***") || !strings.Contains(out, "***MASKED#2***") {
+			t.Errorf("expected distinct tokens for drift:\n%s", out)
+		}
+	})
+
+	t.Run("equal masked values produce no diff line and no difference", func(t *testing.T) {
+		from := newFuncConfig(map[string]any{"DB_PASSWORD": oldSecret})
+		to := newFuncConfig(map[string]any{"DB_PASSWORD": oldSecret})
+		out, hasDiff := runEmitDiff(t, from, to, "", []string{`.Environment.Variables["DB_PASSWORD"]`})
+		if hasDiff {
+			t.Errorf("equal masked values reported a difference:\n%s", out)
+		}
+		if out != "" {
+			t.Errorf("equal masked values produced output:\n%s", out)
+		}
+	})
+}
+
+func TestEmitDiffMaskExternal(t *testing.T) {
+	const oldSecret = "old-secret-value"
+	const newSecret = "new-secret-value"
+
+	app := &lambroll.App{}
+	opt := &lambroll.DiffOption{External: "cat"}
+	var buf bytes.Buffer
+	opt.SetWriter(&buf)
+	reg := lambroll.NewMaskTokenRegistry()
+	from := newFuncConfig(map[string]any{"DB_PASSWORD": oldSecret})
+	to := newFuncConfig(map[string]any{"DB_PASSWORD": newSecret})
+
+	d, err := app.EmitDiff(
+		context.Background(), opt, "function.json",
+		&jsondiff.Input{Name: "remote", X: from},
+		&jsondiff.Input{Name: "local", X: to},
+		"", []string{`.Environment.Variables["DB_PASSWORD"]`}, reg,
+	)
+	if err != nil {
+		t.Fatalf("emitDiff error: %v", err)
+	}
+	if !d {
+		t.Fatal("expected a difference")
+	}
+	out := buf.String()
+	if strings.Contains(out, oldSecret) || strings.Contains(out, newSecret) {
+		t.Errorf("raw value leaked into external diff input:\n%s", out)
+	}
+	if !strings.Contains(out, "***MASKED#") {
+		t.Errorf("expected a mask token in external diff input:\n%s", out)
+	}
+}
+
+func TestEmitDiffMaskWholeObject(t *testing.T) {
+	from := newFuncConfig(map[string]any{"DB_PASSWORD": "p1", "API_KEY": "k1"})
+	to := newFuncConfig(map[string]any{"DB_PASSWORD": "p2", "API_KEY": "k2"})
+	out, hasDiff := runEmitDiff(t, from, to, "", []string{".Environment.Variables"})
+	if !hasDiff {
+		t.Fatal("expected a difference")
+	}
+	for _, raw := range []string{"p1", "p2", "k1", "k2", "DB_PASSWORD", "API_KEY"} {
+		if strings.Contains(out, raw) {
+			t.Errorf("whole-object mask leaked %q:\n%s", raw, out)
+		}
+	}
+	if !strings.Contains(out, "***MASKED#") {
+		t.Errorf("expected a mask token:\n%s", out)
+	}
+}
+
+func TestEmitDiffNoMaskByteIdentical(t *testing.T) {
+	// disable coloring so the byte comparison is deterministic regardless of TTY
+	prev := color.NoColor
+	color.NoColor = true
+	defer func() { color.NoColor = prev }()
+
+	const secret = "secret-value"
+	from := newFuncConfig(map[string]any{"DB_PASSWORD": secret, "PLAIN": "old"})
+	to := newFuncConfig(map[string]any{"DB_PASSWORD": secret, "PLAIN": "new"})
+
+	withEmpty, hasDiffEmpty := runEmitDiff(t, from, to, "", nil)
+
+	// pre-feature equivalent: jsondiff then the same coloring emitDiff applies
+	pre, err := jsondiff.Diff(
+		&jsondiff.Input{Name: "remote", X: from},
+		&jsondiff.Input{Name: "local", X: to},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !hasDiffEmpty {
+		t.Fatal("expected a difference on the unmasked field")
+	}
+	if !strings.Contains(withEmpty, "old") || !strings.Contains(withEmpty, "new") {
+		t.Errorf("empty mask set should not mask anything:\n%s", withEmpty)
+	}
+	if want := coloredLikeEmitDiff(pre); withEmpty != want {
+		t.Errorf("empty mask set not byte-identical to pre-feature diff:\ngot:  %q\nwant: %q", withEmpty, want)
+	}
+}
+
+func coloredLikeEmitDiff(src string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		b.WriteString(line + "\n")
+	}
+	return b.String()
+}
+
+func TestEmitDiffMaskIsolation(t *testing.T) {
+	const secret = "isolation-secret"
+	from := newFuncConfig(map[string]any{"DB_PASSWORD": secret})
+	to := newFuncConfig(map[string]any{"DB_PASSWORD": "other-secret"})
+
+	_, _ = runEmitDiff(t, from, to, "", []string{`.Environment.Variables["DB_PASSWORD"]`})
+
+	gotFrom := from["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"]
+	if gotFrom != secret {
+		t.Errorf("original 'from' input was mutated: %q", gotFrom)
+	}
+	gotTo := to["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"]
+	if gotTo != "other-secret" {
+		t.Errorf("original 'to' input was mutated: %q", gotTo)
+	}
+}
+
+func TestEmitDiffMaskSurfaceRestriction(t *testing.T) {
+	// Simulate the CodeSha256 path: string inputs, no selectors.
+	app := &lambroll.App{}
+	opt := &lambroll.DiffOption{}
+	var buf bytes.Buffer
+	opt.SetWriter(&buf)
+	reg := lambroll.NewMaskTokenRegistry()
+	d, err := app.EmitDiff(
+		context.Background(), opt, "CodeSha256.txt",
+		&jsondiff.Input{Name: "remote", X: "CodeSha256: abc123"},
+		&jsondiff.Input{Name: "--src=.", X: "CodeSha256: def456"},
+		"", nil, reg,
+	)
+	if err != nil {
+		t.Fatalf("emitDiff error: %v", err)
+	}
+	if !d {
+		t.Fatal("expected a difference")
+	}
+	out := buf.String()
+	if strings.Contains(out, "***MASKED#") {
+		t.Errorf("CodeSha256 surface must never be masked:\n%s", out)
+	}
+	if !strings.Contains(out, "abc123") || !strings.Contains(out, "def456") {
+		t.Errorf("CodeSha256 raw values should be visible:\n%s", out)
+	}
+}
+
+func TestMaskInputIgnoreThenMask(t *testing.T) {
+	const secret = "overlap-secret"
+	in := newFuncConfig(map[string]any{"DB_PASSWORD": secret, "KEEP": "keep-me"})
+	// ignore removes DB_PASSWORD; the mask selector then matches nothing.
+	out, err := lambroll.MaskInput(
+		in,
+		`.Environment.Variables["DB_PASSWORD"]`,
+		[]string{`.Environment.Variables["DB_PASSWORD"]`},
+		lambroll.NewMaskTokenRegistry(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vars := out.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)
+	if _, ok := vars["DB_PASSWORD"]; ok {
+		t.Errorf("ignored field should be removed before masking: %v", vars)
+	}
+	if vars["KEEP"] != "keep-me" {
+		t.Errorf("non-ignored, non-masked field altered: %v", vars["KEEP"])
+	}
+	// original input must remain intact (deep-copy isolation)
+	if in["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"] != secret {
+		t.Error("maskInput mutated the original input")
+	}
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,9 +1,12 @@
 package lambroll
 
 import (
+	"context"
 	"io"
 	"os"
 	"sync"
+
+	"github.com/aereal/jsondiff"
 )
 
 var (
@@ -22,7 +25,37 @@ var (
 	IsAWSManagedTag         = isAWSManagedTag
 	RunExternalDiff         = runExternalDiff
 	RenderForExternalDiff   = renderForExternalDiff
+
+	// masking core (mask.go)
+	ResolveMaskSelector   = resolveMaskSelector
+	BuildEffectiveMaskSet = buildEffectiveMaskSet
+	Canonicalize          = canonicalize
+	ApplyMask             = applyMask
+	MaskInput             = maskInput
 )
+
+// MaskTokenRegistry re-exports the per-run token registry for white-box tests.
+type MaskTokenRegistry = maskTokenRegistry
+
+// NewMaskTokenRegistry re-exports the registry constructor for white-box tests.
+func NewMaskTokenRegistry() *MaskTokenRegistry {
+	return newMaskTokenRegistry()
+}
+
+// TokenFor re-exports the unexported tokenFor method for white-box tests.
+func (r *MaskTokenRegistry) TokenFor(canonical string) string {
+	return r.tokenFor(canonical)
+}
+
+// NextCounter exposes the registry's internal counter for white-box assertions.
+func (r *MaskTokenRegistry) NextCounter() int {
+	return r.nextCounter
+}
+
+// EmitDiff re-exports the unexported emitDiff method for white-box tests.
+func (app *App) EmitDiff(ctx context.Context, opt *DiffOption, label string, from, to *jsondiff.Input, ignore string, maskSelectors []string, maskReg *MaskTokenRegistry) (bool, error) {
+	return app.emitDiff(ctx, opt, label, from, to, ignore, maskSelectors, maskReg)
+}
 
 func (o *DiffOption) SetWriter(w io.Writer) {
 	o.w = w

--- a/mask.go
+++ b/mask.go
@@ -1,0 +1,312 @@
+package lambroll
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/aereal/jsondiff"
+	"github.com/itchyny/gojq"
+)
+
+const (
+	maskTokenPrefix = "***MASKED#"
+	maskTokenSuffix = "***"
+)
+
+const (
+	envVarSelectorPrefix = `.Environment.Variables["`
+	envVarSelectorSuffix = `"]`
+)
+
+// maskTokenRegistry maps each distinct canonical value to a stable token for a
+// single diff run. Equal values share a token; distinct values get distinct
+// tokens from a global counter in encounter order.
+type maskTokenRegistry struct {
+	valueToToken map[string]string
+	nextCounter  int
+}
+
+func newMaskTokenRegistry() *maskTokenRegistry {
+	return &maskTokenRegistry{
+		valueToToken: map[string]string{},
+		nextCounter:  1,
+	}
+}
+
+func (r *maskTokenRegistry) tokenFor(canonical string) string {
+	if tok, ok := r.valueToToken[canonical]; ok {
+		return tok
+	}
+	tok := fmt.Sprintf("%s%d%s", maskTokenPrefix, r.nextCounter, maskTokenSuffix)
+	r.valueToToken[canonical] = tok
+	r.nextCounter++
+	return tok
+}
+
+// resolveMaskSelector classifies a mask argument. An argument starting with "."
+// is used verbatim as a jq selector; otherwise it is an environment variable
+// name expanded to .Environment.Variables["<name>"]. A dotless argument that
+// looks like a selector (contains "." "[" or "|") returns warn=true.
+func resolveMaskSelector(arg string) (selector string, warn bool) {
+	if strings.HasPrefix(arg, ".") {
+		return arg, false
+	}
+	warn = strings.ContainsAny(arg, ".[|")
+	return envVarSelectorPrefix + arg + envVarSelectorSuffix, warn
+}
+
+// buildEffectiveMaskSet resolves and de-duplicates all mask arguments, keeping
+// first-occurrence order with option-file entries before CLI entries. A mistyped
+// dotless argument is warned about but still used as a name.
+func buildEffectiveMaskSet(cliMasks, optionMasks []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(cliMasks)+len(optionMasks))
+
+	add := func(args []string) {
+		for _, arg := range args {
+			selector, warn := resolveMaskSelector(arg)
+			if warn {
+				slog.Warn("mask argument looks like a selector but does not start with '.'; treating it as an environment variable name", "argument", arg, "resolved", selector)
+			}
+			if _, ok := seen[selector]; ok {
+				continue
+			}
+			seen[selector] = struct{}{}
+			result = append(result, selector)
+		}
+	}
+
+	add(optionMasks)
+	add(cliMasks)
+	return result
+}
+
+// canonicalize reduces a matched value to a stable string used as the registry
+// key, so structurally-equal values collapse to the same token. json.Marshal
+// sorts object keys, so equal values always produce the same key.
+func canonicalize(value any) (string, error) {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("failed to canonicalize masked value: %w", err)
+	}
+	return string(b), nil
+}
+
+// applyMask replaces every value matched by selectors with a token, in place. A
+// selector that matches nothing warns and is a no-op; one that fails to evaluate
+// returns an error (so a value is never silently left unmasked); a root selector
+// (".", "..") collapses the whole value to one token. root must be a deep copy.
+func applyMask(root any, selectors []string, reg *maskTokenRegistry) (any, error) {
+	for _, selector := range selectors {
+		query, err := gojq.Parse("path(" + selector + ")")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse mask selector %q: %w", selector, err)
+		}
+		paths, err := enumeratePaths(query, root)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate mask selector %q: %w", selector, err)
+		}
+		matched := 0
+		for _, path := range paths {
+			if len(path) == 0 {
+				// the selector targets the whole document root; replace the
+				// entire value with one token (it cannot be set in place).
+				canonical, err := canonicalize(root)
+				if err != nil {
+					return nil, err
+				}
+				return reg.tokenFor(canonical), nil
+			}
+			rawValue, exists, err := getValueAtPath(root, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to apply mask selector %q: %w", selector, err)
+			}
+			if !exists {
+				continue
+			}
+			matched++
+			canonical, err := canonicalize(rawValue)
+			if err != nil {
+				return nil, err
+			}
+			if err := setValueAtPath(root, path, reg.tokenFor(canonical)); err != nil {
+				return nil, fmt.Errorf("failed to apply mask selector %q: %w", selector, err)
+			}
+		}
+		if matched == 0 {
+			slog.Warn("mask selector matched nothing", "selector", selector)
+		}
+	}
+	return root, nil
+}
+
+// enumeratePaths returns the paths matched by a path(...) query. Iterating an
+// absent/null node (e.g. ".Environment.Variables[]" on a function with no
+// Environment) counts as no match; any other evaluation error is returned so an
+// invalid selector fails loudly instead of leaving a value unmasked.
+func enumeratePaths(query *gojq.Query, root any) ([][]any, error) {
+	var paths [][]any
+	iter := query.Run(root)
+	for {
+		got, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, isErr := got.(error); isErr {
+			if isNullIterationError(err) {
+				return paths, nil
+			}
+			return nil, err
+		}
+		path, ok := got.([]any)
+		if !ok {
+			return nil, fmt.Errorf("expected a path but got %T", got)
+		}
+		paths = append(paths, path)
+	}
+	return paths, nil
+}
+
+// isNullIterationError reports whether err is gojq's "cannot iterate over: null"
+// error, raised when a "[]" selector iterates an absent/null node. The message
+// is matched literally because gojq's iteratorError type is unexported; gojq is
+// version-pinned in go.mod and TestApplyMaskAbsentIterable guards this.
+func isNullIterationError(err error) bool {
+	return err != nil && err.Error() == "cannot iterate over: null"
+}
+
+// getValueAtPath returns the value at a gojq path and whether it exists. path()
+// yields paths for missing keys too, so the exists flag distinguishes a real
+// match from a path that points at nothing. An unsupported path element (e.g. an
+// array slice) is returned as an error rather than silently treated as absent.
+func getValueAtPath(root any, path []any) (any, bool, error) {
+	cur := root
+	for _, p := range path {
+		switch key := p.(type) {
+		case string:
+			m, ok := cur.(map[string]any)
+			if !ok {
+				return nil, false, nil
+			}
+			v, ok := m[key]
+			if !ok {
+				return nil, false, nil
+			}
+			cur = v
+		case int:
+			arr, ok := cur.([]any)
+			if !ok {
+				return nil, false, nil
+			}
+			idx := arrayIndex(key, len(arr))
+			if idx < 0 || idx >= len(arr) {
+				return nil, false, nil
+			}
+			cur = arr[idx]
+		default:
+			return nil, false, fmt.Errorf("unsupported mask selector path element %v (%T)", p, p)
+		}
+	}
+	return cur, true, nil
+}
+
+// arrayIndex resolves a gojq path index, which may be negative (counted from the
+// end), to an absolute index.
+func arrayIndex(key, length int) int {
+	if key < 0 {
+		return key + length
+	}
+	return key
+}
+
+// setValueAtPath writes token at the given gojq path within root.
+func setValueAtPath(root any, path []any, token string) error {
+	if len(path) == 0 {
+		return fmt.Errorf("cannot set value at empty path")
+	}
+	cur := root
+	for i, p := range path[:len(path)-1] {
+		switch key := p.(type) {
+		case string:
+			m, ok := cur.(map[string]any)
+			if !ok {
+				return fmt.Errorf("mask path element %d (%q) is not an object", i, key)
+			}
+			cur = m[key]
+		case int:
+			arr, ok := cur.([]any)
+			if !ok {
+				return fmt.Errorf("mask path element %d (%d) is not an array", i, key)
+			}
+			idx := arrayIndex(key, len(arr))
+			if idx < 0 || idx >= len(arr) {
+				return fmt.Errorf("mask path index %d out of range", key)
+			}
+			cur = arr[idx]
+		default:
+			return fmt.Errorf("unsupported mask path element type %T", p)
+		}
+	}
+	switch key := path[len(path)-1].(type) {
+	case string:
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return fmt.Errorf("mask path leaf (%q) is not in an object", key)
+		}
+		m[key] = token
+	case int:
+		arr, ok := cur.([]any)
+		if !ok {
+			return fmt.Errorf("mask path leaf (%d) is not in an array", key)
+		}
+		idx := arrayIndex(key, len(arr))
+		if idx < 0 || idx >= len(arr) {
+			return fmt.Errorf("mask path leaf index %d out of range", key)
+		}
+		arr[idx] = token
+	default:
+		return fmt.Errorf("unsupported mask path leaf type %T", path[len(path)-1])
+	}
+	return nil
+}
+
+// deepCopyJSONValue returns a deep copy of a JSON-decoded value via a round-trip,
+// so masking never mutates the original local definition or remote configuration.
+func deepCopyJSONValue(x any) (any, error) {
+	b, err := json.Marshal(x)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deep-copy value for masking: %w", err)
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, fmt.Errorf("failed to deep-copy value for masking: %w", err)
+	}
+	return out, nil
+}
+
+// maskInput returns x with ignore then mask applied to a deep copy. With no
+// selectors it returns x unchanged. The returned value already has ignore
+// applied, so callers must not apply it again.
+func maskInput(x any, ignore string, selectors []string, reg *maskTokenRegistry) (any, error) {
+	if len(selectors) == 0 {
+		return x, nil
+	}
+	copied, err := deepCopyJSONValue(x)
+	if err != nil {
+		return nil, err
+	}
+	if ignore != "" {
+		q, err := gojq.Parse("del(" + ignore + ")")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ignore query: %s %w", ignore, err)
+		}
+		modified, err := jsondiff.ModifyValue(q, copied)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply ignore query: %w", err)
+		}
+		copied = modified
+	}
+	return applyMask(copied, selectors, reg)
+}

--- a/mask_test.go
+++ b/mask_test.go
@@ -1,0 +1,475 @@
+package lambroll_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fujiwara/lambroll"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestResolveMaskSelector(t *testing.T) {
+	tests := []struct {
+		name         string
+		arg          string
+		wantSelector string
+		wantWarn     bool
+	}{
+		{
+			name:         "dot-prefixed selector used verbatim",
+			arg:          ".Environment.Variables",
+			wantSelector: ".Environment.Variables",
+			wantWarn:     false,
+		},
+		{
+			name:         "dot-prefixed per-value selector used verbatim",
+			arg:          ".Environment.Variables[]",
+			wantSelector: ".Environment.Variables[]",
+			wantWarn:     false,
+		},
+		{
+			name:         "dotless name expanded to env-var selector",
+			arg:          "DB_PASSWORD",
+			wantSelector: `.Environment.Variables["DB_PASSWORD"]`,
+			wantWarn:     false,
+		},
+		{
+			name:         "env-var name matching is case-sensitive (lower)",
+			arg:          "db_password",
+			wantSelector: `.Environment.Variables["db_password"]`,
+			wantWarn:     false,
+		},
+		{
+			name:         "dotless containing dot warns but still treated as name",
+			arg:          "Environment.Variables",
+			wantSelector: `.Environment.Variables["Environment.Variables"]`,
+			wantWarn:     true,
+		},
+		{
+			name:         "dotless containing bracket warns",
+			arg:          "Variables[FOO]",
+			wantSelector: `.Environment.Variables["Variables[FOO]"]`,
+			wantWarn:     true,
+		},
+		{
+			name:         "dotless containing pipe warns",
+			arg:          "A|B",
+			wantSelector: `.Environment.Variables["A|B"]`,
+			wantWarn:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSelector, gotWarn := lambroll.ResolveMaskSelector(tt.arg)
+			if gotSelector != tt.wantSelector {
+				t.Errorf("selector: got %q, want %q", gotSelector, tt.wantSelector)
+			}
+			if gotWarn != tt.wantWarn {
+				t.Errorf("warn: got %v, want %v", gotWarn, tt.wantWarn)
+			}
+		})
+	}
+}
+
+func TestResolveMaskSelectorCaseSensitive(t *testing.T) {
+	upper, _ := lambroll.ResolveMaskSelector("DB_PASSWORD")
+	lower, _ := lambroll.ResolveMaskSelector("db_password")
+	if upper == lower {
+		t.Errorf("expected case-sensitive distinct selectors, both %q", upper)
+	}
+}
+
+func TestBuildEffectiveMaskSet(t *testing.T) {
+	tests := []struct {
+		name   string
+		cli    []string
+		option []string
+		want   []string
+	}{
+		{
+			name:   "empty produces empty",
+			cli:    nil,
+			option: nil,
+			want:   []string{},
+		},
+		{
+			name:   "option only",
+			cli:    nil,
+			option: []string{"DB_PASSWORD", ".Environment.Variables"},
+			want: []string{
+				`.Environment.Variables["DB_PASSWORD"]`,
+				".Environment.Variables",
+			},
+		},
+		{
+			name:   "cli added on top of option",
+			cli:    []string{"API_KEY"},
+			option: []string{"DB_PASSWORD"},
+			want: []string{
+				`.Environment.Variables["DB_PASSWORD"]`,
+				`.Environment.Variables["API_KEY"]`,
+			},
+		},
+		{
+			name:   "duplicate across sources deduped, option order wins",
+			cli:    []string{"DB_PASSWORD", "API_KEY"},
+			option: []string{"DB_PASSWORD"},
+			want: []string{
+				`.Environment.Variables["DB_PASSWORD"]`,
+				`.Environment.Variables["API_KEY"]`,
+			},
+		},
+		{
+			name:   "dot and name resolving to same selector dedupe",
+			cli:    []string{`.Environment.Variables["X"]`},
+			option: []string{"X"},
+			want: []string{
+				`.Environment.Variables["X"]`,
+			},
+		},
+		{
+			name:   "duplicates within one source deduped",
+			cli:    []string{"A", "A", "B"},
+			option: nil,
+			want: []string{
+				`.Environment.Variables["A"]`,
+				`.Environment.Variables["B"]`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lambroll.BuildEffectiveMaskSet(tt.cli, tt.option)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("effective mask set (-want +got):\n%s", diff)
+			}
+
+			// fail-safe: size never below deduped option count.
+			dedupedOption := map[string]struct{}{}
+			for _, o := range tt.option {
+				sel, _ := lambroll.ResolveMaskSelector(o)
+				dedupedOption[sel] = struct{}{}
+			}
+			if len(got) < len(dedupedOption) {
+				t.Errorf("effective set size %d < deduped option count %d", len(got), len(dedupedOption))
+			}
+		})
+	}
+}
+
+func TestMaskTokenRegistry(t *testing.T) {
+	reg := lambroll.NewMaskTokenRegistry()
+	if got := reg.NextCounter(); got != 1 {
+		t.Fatalf("initial counter = %d, want 1", got)
+	}
+
+	a := reg.TokenFor(`"alpha"`)
+	if a != "***MASKED#1***" {
+		t.Errorf("first token = %q, want ***MASKED#1***", a)
+	}
+	b := reg.TokenFor(`"beta"`)
+	if b != "***MASKED#2***" {
+		t.Errorf("second token = %q, want ***MASKED#2***", b)
+	}
+	// collapse-equals: same canonical form reuses the token, counter unchanged.
+	aAgain := reg.TokenFor(`"alpha"`)
+	if aAgain != a {
+		t.Errorf("collapse-equals failed: got %q, want %q", aAgain, a)
+	}
+	if got := reg.NextCounter(); got != 3 {
+		t.Errorf("counter after 2 distinct + 1 repeat = %d, want 3", got)
+	}
+	c := reg.TokenFor(`"gamma"`)
+	if c != "***MASKED#3***" {
+		t.Errorf("third distinct token = %q, want ***MASKED#3***", c)
+	}
+	if a == b || a == c || b == c {
+		t.Errorf("distinct values produced non-distinct tokens: %q %q %q", a, b, c)
+	}
+}
+
+func TestCanonicalizeCollapsesEqualObjects(t *testing.T) {
+	o1 := map[string]any{"A": "1", "B": "2"}
+	o2 := map[string]any{"B": "2", "A": "1"}
+	c1, err := lambroll.Canonicalize(o1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := lambroll.Canonicalize(o2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c1 != c2 {
+		t.Errorf("equal objects canonicalize differently:\n%q\n%q", c1, c2)
+	}
+
+	o3 := map[string]any{"A": "1", "B": "3"}
+	c3, err := lambroll.Canonicalize(o3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c1 == c3 {
+		t.Errorf("different objects canonicalize identically: %q", c1)
+	}
+}
+
+func TestApplyMask(t *testing.T) {
+	const secret = "super-secret-value"
+	const apiKey = "api-key-123"
+
+	t.Run("per-value selector keeps keys, tokenizes each value", func(t *testing.T) {
+		reg := lambroll.NewMaskTokenRegistry()
+		root := map[string]any{
+			"Environment": map[string]any{
+				"Variables": map[string]any{
+					"DB_PASSWORD": secret,
+					"API_KEY":     apiKey,
+				},
+			},
+		}
+		out, err := lambroll.ApplyMask(root, []string{".Environment.Variables[]"}, reg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vars := out.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)
+		if _, ok := vars["DB_PASSWORD"]; !ok {
+			t.Error("DB_PASSWORD key was removed")
+		}
+		if _, ok := vars["API_KEY"]; !ok {
+			t.Error("API_KEY key was removed")
+		}
+		for k, v := range vars {
+			if !strings.HasPrefix(v.(string), "***MASKED#") {
+				t.Errorf("value for %q not masked: %q", k, v)
+			}
+		}
+		assertNoRaw(t, out, secret, apiKey)
+	})
+
+	t.Run("whole-object selector collapses node to one token", func(t *testing.T) {
+		reg := lambroll.NewMaskTokenRegistry()
+		root := map[string]any{
+			"Environment": map[string]any{
+				"Variables": map[string]any{
+					"DB_PASSWORD": secret,
+					"API_KEY":     apiKey,
+				},
+			},
+		}
+		out, err := lambroll.ApplyMask(root, []string{".Environment.Variables"}, reg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		env := out.(map[string]any)["Environment"].(map[string]any)
+		// the Variables key stays present, but its value becomes a single token
+		// (object -> string), hiding both keys and values.
+		val, ok := env["Variables"].(string)
+		if !ok {
+			t.Fatalf("Variables not collapsed to a string token, got %T", env["Variables"])
+		}
+		if !strings.HasPrefix(val, "***MASKED#") {
+			t.Errorf("whole-object value not a token: %q", val)
+		}
+		assertNoRaw(t, out, secret, apiKey, "DB_PASSWORD", "API_KEY")
+	})
+
+	t.Run("scalar selector masks a single value", func(t *testing.T) {
+		reg := lambroll.NewMaskTokenRegistry()
+		root := map[string]any{
+			"Environment": map[string]any{
+				"Variables": map[string]any{
+					"DB_PASSWORD": secret,
+				},
+			},
+		}
+		out, err := lambroll.ApplyMask(root, []string{`.Environment.Variables["DB_PASSWORD"]`}, reg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vars := out.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)
+		if v := vars["DB_PASSWORD"].(string); v != "***MASKED#1***" {
+			t.Errorf("scalar value = %q, want ***MASKED#1***", v)
+		}
+	})
+
+	t.Run("equal local/remote values produce same token (drift invariant)", func(t *testing.T) {
+		reg := lambroll.NewMaskTokenRegistry()
+		local := map[string]any{
+			"Environment": map[string]any{"Variables": map[string]any{"DB_PASSWORD": secret}},
+		}
+		remote := map[string]any{
+			"Environment": map[string]any{"Variables": map[string]any{"DB_PASSWORD": secret}},
+		}
+		sel := []string{`.Environment.Variables["DB_PASSWORD"]`}
+		lOut, _ := lambroll.ApplyMask(local, sel, reg)
+		rOut, _ := lambroll.ApplyMask(remote, sel, reg)
+		lv := lOut.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"]
+		rv := rOut.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"]
+		if lv != rv {
+			t.Errorf("equal values masked to different tokens: %q vs %q", lv, rv)
+		}
+	})
+
+	t.Run("changed local/remote values produce different tokens (drift visible)", func(t *testing.T) {
+		reg := lambroll.NewMaskTokenRegistry()
+		local := map[string]any{
+			"Environment": map[string]any{"Variables": map[string]any{"DB_PASSWORD": "old"}},
+		}
+		remote := map[string]any{
+			"Environment": map[string]any{"Variables": map[string]any{"DB_PASSWORD": "new"}},
+		}
+		sel := []string{`.Environment.Variables["DB_PASSWORD"]`}
+		lOut, _ := lambroll.ApplyMask(local, sel, reg)
+		rOut, _ := lambroll.ApplyMask(remote, sel, reg)
+		lv := lOut.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"]
+		rv := rOut.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"]
+		if lv == rv {
+			t.Errorf("changed values masked to the same token %q", lv)
+		}
+	})
+
+	t.Run("match-nothing selector is a no-op and does not mutate", func(t *testing.T) {
+		reg := lambroll.NewMaskTokenRegistry()
+		root := map[string]any{
+			"Environment": map[string]any{"Variables": map[string]any{"DB_PASSWORD": secret}},
+		}
+		out, err := lambroll.ApplyMask(root, []string{`.Environment.Variables["NOPE"]`}, reg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v := out.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"]
+		if v != secret {
+			t.Errorf("match-nothing selector altered an unrelated value: %q", v)
+		}
+		if got := reg.NextCounter(); got != 1 {
+			t.Errorf("match-nothing selector allocated a token, counter = %d", got)
+		}
+	})
+
+	t.Run("empty selector set is a no-op", func(t *testing.T) {
+		reg := lambroll.NewMaskTokenRegistry()
+		root := map[string]any{
+			"Environment": map[string]any{"Variables": map[string]any{"DB_PASSWORD": secret}},
+		}
+		out, err := lambroll.ApplyMask(root, nil, reg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v := out.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)["DB_PASSWORD"]
+		if v != secret {
+			t.Errorf("empty mask set altered a value: %q", v)
+		}
+	})
+
+	t.Run("global counter spans selectors and equal values collapse cross-path", func(t *testing.T) {
+		reg := lambroll.NewMaskTokenRegistry()
+		root := map[string]any{
+			"Environment": map[string]any{"Variables": map[string]any{
+				"DB_PASSWORD": secret,
+				"COPY":        secret, // same value via a different path
+				"API_KEY":     apiKey,
+			}},
+		}
+		out, err := lambroll.ApplyMask(root, []string{".Environment.Variables[]"}, reg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vars := out.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)
+		if vars["DB_PASSWORD"] != vars["COPY"] {
+			t.Errorf("equal values across paths got different tokens: %q vs %q", vars["DB_PASSWORD"], vars["COPY"])
+		}
+		if vars["DB_PASSWORD"] == vars["API_KEY"] {
+			t.Errorf("distinct values collapsed: %q", vars["API_KEY"])
+		}
+		if got := reg.NextCounter(); got != 3 {
+			t.Errorf("global counter = %d, want 3", got)
+		}
+	})
+}
+
+func TestApplyMaskErroringSelectorFailsLoud(t *testing.T) {
+	root := func() map[string]any {
+		return map[string]any{
+			"Environment": map[string]any{"Variables": map[string]any{"DB_PASSWORD": "super-secret"}},
+			"Layers":      []any{"arn:a", "arn:b"},
+		}
+	}
+	for _, sel := range []string{
+		".Environment.Variables | keys[]", // errors mid-iteration (must not panic)
+		".Environment.Variables[0]",       // indexes a map
+		".Layers[0:2]",                    // array slice (unsupported path element)
+	} {
+		t.Run(sel, func(t *testing.T) {
+			reg := lambroll.NewMaskTokenRegistry()
+			if _, err := lambroll.ApplyMask(root(), []string{sel}, reg); err == nil {
+				t.Errorf("expected an error for selector %q, got nil (a silent no-op would leave the value unmasked)", sel)
+			}
+		})
+	}
+}
+
+func TestApplyMaskRootSelectorMasksWholeDocument(t *testing.T) {
+	reg := lambroll.NewMaskTokenRegistry()
+	root := map[string]any{"Environment": map[string]any{"Variables": map[string]any{"DB_PASSWORD": "super-secret"}}}
+	out, err := lambroll.ApplyMask(root, []string{"."}, reg)
+	if err != nil {
+		t.Fatalf("root selector must not abort the diff: %v", err)
+	}
+	tok, ok := out.(string)
+	if !ok {
+		t.Fatalf("root selector should collapse the document to a token, got %T", out)
+	}
+	if !strings.HasPrefix(tok, "***MASKED#") {
+		t.Errorf("root selector did not produce a mask token: %q", tok)
+	}
+	if strings.Contains(tok, "super-secret") {
+		t.Errorf("raw value leaked into the root token: %q", tok)
+	}
+}
+
+func TestApplyMaskAbsentIterable(t *testing.T) {
+	reg := lambroll.NewMaskTokenRegistry()
+	root := map[string]any{"FunctionName": "f"} // no Environment block
+	out, err := lambroll.ApplyMask(root, []string{".Environment.Variables[]"}, reg)
+	if err != nil {
+		t.Fatalf("iterating an absent node must not fail: %v", err)
+	}
+	if out.(map[string]any)["FunctionName"] != "f" {
+		t.Errorf("absent-iterable selector altered the document: %v", out)
+	}
+	if got := reg.NextCounter(); got != 1 {
+		t.Errorf("absent-iterable selector allocated a token, counter = %d", got)
+	}
+}
+
+func TestApplyMaskNegativeIndex(t *testing.T) {
+	reg := lambroll.NewMaskTokenRegistry()
+	root := map[string]any{"Layers": []any{"arn:a", "arn:b", "arn:c"}}
+	out, err := lambroll.ApplyMask(root, []string{".Layers[-1]"}, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layers := out.(map[string]any)["Layers"].([]any)
+	if layers[2] == "arn:c" {
+		t.Errorf("negative index did not mask the last element: %v", layers)
+	}
+	if layers[0] != "arn:a" || layers[1] != "arn:b" {
+		t.Errorf("negative index masked the wrong elements: %v", layers)
+	}
+}
+
+func assertNoRaw(t *testing.T, out any, raws ...string) {
+	t.Helper()
+	b, err := lambroll.MarshalJSON(out)
+	if err != nil {
+		t.Fatalf("marshal masked output: %v", err)
+	}
+	s := string(b)
+	for _, raw := range raws {
+		if strings.Contains(s, raw) {
+			t.Errorf("raw value %q leaked into masked output:\n%s", raw, s)
+		}
+	}
+}

--- a/option.go
+++ b/option.go
@@ -34,3 +34,10 @@ func (opt *ZipOption) Expand() error {
 	opt.excludes = append(opt.excludes, excludes...)
 	return nil
 }
+
+// DiffMaskOption holds the diff.mask array from the option file. Its entries
+// may mix the jq-selector form and the environment-variable-name form, and are
+// merged with the --mask CLI values in ParseCLI.
+type DiffMaskOption struct {
+	Mask []string `json:"mask,omitempty"`
+}

--- a/test/cli/diff_mask.jsonnet
+++ b/test/cli/diff_mask.jsonnet
@@ -1,0 +1,8 @@
+{
+  diff: {
+    mask: [
+      'DB_PASSWORD',
+      '.Environment.Variables["API_KEY"]',
+    ],
+  },
+}


### PR DESCRIPTION
## Summary

`lambroll diff --mask` hides resolved secret values in `diff` output while still
showing whether they changed. It is a display-only feature — `deploy` behavior is
unchanged.

## Motivation

lambroll resolves template/Jsonnet functions when it loads a function definition,
so a secret referenced via `ssm(...)` — for example an SSM `SecureString`
parameter used as an environment variable value — is expanded to its decrypted
value in the rendered config. `lambroll diff` then prints that plaintext to the
terminal, CI logs, or an external diff tool.

`--ignore` can drop the field from the comparison entirely, but then you lose
visibility into whether it changed. `--mask` keeps the field but replaces its
value with an opaque token, so drift stays visible without exposing the secret.

## Usage

```console
$ lambroll diff --mask DB_PASSWORD                  # env var by name
$ lambroll diff --mask '.Environment.Variables[]'   # all env var values (jq selector)
```

- An argument beginning with `.` is used as a jq selector (the same grammar as
  `--ignore`); otherwise it is a Lambda environment variable name expanded to
  `.Environment.Variables["<name>"]` (case-sensitive). The flag is repeatable.
  The name shortcut targets `Environment.Variables` because that is where such
  resolved secrets land; the jq form can mask any field.
- Defaults can be set in the option file under `diff.mask`, combined with any
  `--mask` flags (CLI added on top, never replacing the configured list):

```jsonnet
{
  diff: {
    mask: [
      'DB_PASSWORD',
      'API_KEY',
      '.Environment.Variables[]',
    ],
  },
}
```

## Behavior

Each distinct value is replaced with a per-run token `***MASKED#<n>***`. Equal
values share a token (unchanged → no diff line); changed values get different
tokens, so drift stays visible without revealing the value:

```diff
   "Environment": {
     "Variables": {
-      "DB_PASSWORD": "***MASKED#1***"
+      "DB_PASSWORD": "***MASKED#2***"
     }
   }
```

- `--mask '.Environment.Variables'` masks the whole map (hiding the variable
  names too); `--mask '.Environment.Variables[]'` keeps the names visible and
  masks each value.
- Masking applies only to the function configuration diff (not the CodeSha256,
  function URL, or permissions diffs) and to every render path (built-in diff,
  `--external` temp files, and external command input).
- A selector that matches nothing warns and is a no-op; one that fails to
  evaluate errors loudly, so a value is never silently left unmasked; iterating
  an absent node (e.g. `.Environment.Variables[]` on a function with no
  `Environment`) is a no-op; a root selector (`.`) masks the whole document.
- With no `--mask` and no `diff.mask`, output is byte-identical to before.

## Tests

Added unit tests for selector disambiguation, the token registry,
canonicalization, masking, the diff integration (built-in and external),
option-file/CLI merge, and edge cases (erroring / root / negative-index /
absent-iterable selectors, and byte-identical output when the feature is unused).
`go test -race ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
