### PR TITLE
Add --mask to hide sensitive values in diff and render output

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,41 @@ $ LAMBROLL_DIFF_COMMAND="difft --color=always" lambroll diff
 
 The command must exit with status 0. If it exits with a non-zero status when the two files differ (for example, `diff(1)`), you need to write a wrapper command.
 
+##### Mask sensitive values
+
+lambroll resolves template/Jsonnet functions (such as `ssm(...)`) when it loads the function definition, so a secret referenced from a `SecureString` parameter is expanded to its plaintext value in the rendered config and would be printed by `lambroll diff`. Unlike `--ignore`, which drops a field from the comparison entirely, `--mask` keeps the field but replaces its value with an opaque token, so drift stays visible without exposing the value.
+
+```console
+$ lambroll diff --mask DB_PASSWORD                  # environment variable by name
+$ lambroll diff --mask '.Environment.Variables[]'   # all environment variable values (jq selector)
+```
+
+An argument beginning with `.` is used as a jq selector (the same grammar as `--ignore`); otherwise it is a Lambda environment variable name expanded to `.Environment.Variables["<name>"]` (case-sensitive). The flag is repeatable.
+
+Each distinct value is replaced with a per-run token `***MASKED#<n>***`. Equal values share a token (so an unchanged value produces no diff line) and changed values get different tokens, so drift stays visible without revealing the value:
+
+```diff
+   "Environment": {
+     "Variables": {
+-      "DB_PASSWORD": "***MASKED#1***"
++      "DB_PASSWORD": "***MASKED#2***"
+     }
+   }
+```
+
+Masking applies only to the function configuration diff (not the CodeSha256, function URL, or permissions diffs) and to every render path (built-in diff and `--external`). A selector that matches nothing (including one that points at an absent field) warns and is a no-op without fabricating a field; an invalid selector errors. Defaults can be set in the option file under `diff.mask`; a `--mask` flag on the command line replaces the configured list.
+
+```jsonnet
+{
+  diff: {
+    mask: [
+      'DB_PASSWORD',
+      '.Environment.Variables[]',
+    ],
+  },
+}
+```
+
 #### Status
 
 ```console

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ $ lambroll render --mask DB_PASSWORD     # Mask sensitive values in the output
 
 Useful for debugging template variable expansion.
 
-`--mask` works the same way as [`lambroll diff --mask`](#mask-sensitive-values): an argument starting with `.` is a jq selector, otherwise it is an environment variable name. It replaces matched values with `***MASKED***` tokens so the rendered definition (which has secrets such as `ssm(...)` expanded to plaintext) can be shared or inspected without leaking them. Defaults can be set in the option file under `render.mask`.
+`--mask` works the same way as [`lambroll diff --mask`](#mask-sensitive-values): an argument starting with `.` is a jq selector, otherwise it is an environment variable name. It replaces matched values with `***MASKED#<n>***` tokens (equal values share a token) so the rendered definition (which has secrets such as `ssm(...)` expanded to plaintext) can be shared or inspected without leaking them. Defaults can be set in the option file under `render.mask`.
 
 #### Versions
 

--- a/README.md
+++ b/README.md
@@ -658,9 +658,12 @@ Renders `function.json` with all template variables expanded and outputs to STDO
 ```console
 $ lambroll render --jsonnet              # Convert output to Jsonnet format
 $ lambroll render --function-url path    # Render function URL config instead
+$ lambroll render --mask DB_PASSWORD     # Mask sensitive values in the output
 ```
 
 Useful for debugging template variable expansion.
+
+`--mask` works the same way as [`lambroll diff --mask`](#mask-sensitive-values): an argument starting with `.` is a jq selector, otherwise it is an environment variable name. It replaces matched values with `***MASKED***` tokens so the rendered definition (which has secrets such as `ssm(...)` expanded to plaintext) can be shared or inspected without leaking them. Defaults can be set in the option file under `render.mask`.
 
 #### Versions
 

--- a/cli.go
+++ b/cli.go
@@ -81,6 +81,14 @@ type CLIOptions struct {
 	Versions *VersionsOption `cmd:"versions" help:"show versions of function" json:"versions,omitempty"`
 
 	Version struct{} `cmd:"version" help:"show version" json:"-"`
+
+	// LegacyExtStr and LegacyExtCode accept the pre-v1.3.1 option file key
+	// names (extstr/extcode). They are excluded from CLI parsing (kong:"-")
+	// and only exist so the strict loader accepts these deprecated keys;
+	// applyLegacyExtVars folds them into ExtStr/ExtCode.
+	// TODO: Remove in v2.
+	LegacyExtStr  map[string]string `kong:"-" json:"extstr,omitempty"`
+	LegacyExtCode map[string]string `kong:"-" json:"extcode,omitempty"`
 }
 
 // RequireStrict marks CLIOptions as a strict definition loader: when loaded from
@@ -88,6 +96,26 @@ type CLIOptions struct {
 // file is equivalent to specifying flags, so an unknown key is treated the same
 // as an unknown flag.
 func (CLIOptions) RequireStrict() {}
+
+// applyLegacyExtVars folds the deprecated extstr/extcode option file fields into
+// ExtStr/ExtCode. The current field wins if both are set.
+// TODO: Remove in v2.
+func (o *CLIOptions) applyLegacyExtVars() {
+	if o.LegacyExtStr != nil {
+		slog.Warn(`option file key "extstr" is deprecated; use "ext_str" instead. This will be removed in v2.`)
+		if o.ExtStr == nil {
+			o.ExtStr = o.LegacyExtStr
+		}
+		o.LegacyExtStr = nil
+	}
+	if o.LegacyExtCode != nil {
+		slog.Warn(`option file key "extcode" is deprecated; use "ext_code" instead. This will be removed in v2.`)
+		if o.ExtCode == nil {
+			o.ExtCode = o.LegacyExtCode
+		}
+		o.LegacyExtCode = nil
+	}
+}
 
 type CLIParseFunc func([]string) (string, *CLIOptions, func(), error)
 
@@ -159,6 +187,7 @@ func ParseCLI(args []string) (string, *CLIOptions, func(), error) {
 	// Merge ext_str and ext_code from option file with CLI args
 	// CLI args take precedence over option file values
 	if defaultOpt != nil {
+		defaultOpt.applyLegacyExtVars() // accept deprecated extstr/extcode keys
 		if defaultOpt.ExtStr != nil || opts.ExtStr != nil {
 			opts.ExtStr = lo.Assign(defaultOpt.ExtStr, opts.ExtStr)
 		}

--- a/cli_test.go
+++ b/cli_test.go
@@ -189,6 +189,27 @@ var cliTests = []struct {
 		},
 	},
 	{
+		// Test: deprecated extstr/extcode keys are still accepted (v1 compat).
+		args: []string{"render", "--option", "ext_vars_legacy.jsonnet"},
+		sub:  "render",
+		option: &lambroll.Option{
+			OptionFilePath: "ext_vars_legacy.jsonnet",
+			LogLevel:       "info",
+			LogFormat:      "text",
+			Color:          true,
+			Envfile:        []string{},
+			ExtStr: map[string]string{
+				"architecture": "x86_64",
+				"description":  "Test function with ext_str and ext_code",
+			},
+			ExtCode: map[string]string{
+				"memory_size":  "128",
+				"storage_size": "512",
+				"timeout":      "30",
+			},
+		},
+	},
+	{
 		// Test: CLI args are merged with option file, CLI takes precedence
 		args: []string{
 			"render", "--option", "ext_vars.jsonnet",

--- a/cli_test.go
+++ b/cli_test.go
@@ -275,6 +275,29 @@ func TestParseCLISubcommandOption(t *testing.T) {
 			t.Error("deploy.publish: expected false from option file, got true")
 		}
 	})
+
+	t.Run("diff.mask from option file", func(t *testing.T) {
+		_, opt, _, err := lambroll.ParseCLI([]string{"diff", "--option", "diff_mask.jsonnet"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"DB_PASSWORD", ".Environment.Variables[]"}
+		if diff := cmp.Diff(want, opt.Diff.Mask); diff != "" {
+			t.Errorf("diff.mask not resolved from option file: %s", diff)
+		}
+	})
+
+	// A repeatable slice flag given on the CLI replaces the option-file value
+	// (uniform with every other flag: option file = default, CLI overrides).
+	t.Run("CLI --mask replaces option file diff.mask", func(t *testing.T) {
+		_, opt, _, err := lambroll.ParseCLI([]string{"diff", "--option", "diff_mask.jsonnet", "--mask", "FOO"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff([]string{"FOO"}, opt.Diff.Mask); diff != "" {
+			t.Errorf("CLI --mask should replace option file diff.mask: %s", diff)
+		}
+	})
 }
 
 func TestParseCLI(t *testing.T) {

--- a/cli_test.go
+++ b/cli_test.go
@@ -298,6 +298,16 @@ func TestParseCLISubcommandOption(t *testing.T) {
 			t.Errorf("CLI --mask should replace option file diff.mask: %s", diff)
 		}
 	})
+
+	t.Run("render.mask from option file", func(t *testing.T) {
+		_, opt, _, err := lambroll.ParseCLI([]string{"render", "--option", "render_mask.jsonnet"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff([]string{"DB_PASSWORD"}, opt.Render.Mask); diff != "" {
+			t.Errorf("render.mask not resolved from option file: %s", diff)
+		}
+	})
 }
 
 func TestParseCLI(t *testing.T) {

--- a/diff.go
+++ b/diff.go
@@ -36,6 +36,8 @@ type DiffOption struct {
 	SkipFunction bool    `help:"skip function diff. shows function-url only" default:"false" json:"skip_function,omitempty"`
 	External     string  `help:"external command to display diff" default:"" env:"LAMBROLL_DIFF_COMMAND" json:"external,omitempty"`
 
+	Mask []string `help:"mask values in diff output by jq selector or environment variable name (repeatable)" json:"mask,omitempty"`
+
 	ZipOption
 
 	w io.Writer `kong:"-" json:"-"`
@@ -129,10 +131,15 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 	remoteArn := fullQualifiedFunctionName(app.functionArn(ctx, name), opt.Qualifier)
 	hasDiff := false
 
+	// masking applies only to the function configuration diff. The selectors are
+	// resolved once and emitDiff shares a single token registry between the two
+	// sides so equal values collapse to the same token.
+	maskSelectors := resolveMaskSelectors(opt.Mask)
+
 	if d, err := app.emitDiff(ctx, opt, "function.json",
 		&jsondiff.Input{Name: remoteArn, X: remoteJSON},
 		&jsondiff.Input{Name: app.functionFilePath, X: newJSON},
-		opt.Ignore,
+		opt.Ignore, maskSelectors,
 	); err != nil {
 		return false, err
 	} else if d {
@@ -161,7 +168,7 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 		if d, err := app.emitDiff(ctx, opt, "CodeSha256.txt",
 			&jsondiff.Input{Name: remoteArn, X: prefix + currentCodeSha256},
 			&jsondiff.Input{Name: "--src=" + opt.Src, X: prefix + newCodeSha256},
-			"",
+			"", nil,
 		); err != nil {
 			return false, err
 		} else if d {
@@ -223,7 +230,7 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 	if d, err := app.emitDiff(ctx, opt, "function_url.json",
 		&jsondiff.Input{Name: fqName, X: r},
 		&jsondiff.Input{Name: opt.FunctionURL, X: l},
-		"",
+		"", nil,
 	); err != nil {
 		return hasDiff, err
 	} else if d {
@@ -238,7 +245,7 @@ func (app *App) diffFunctionURL(ctx context.Context, name string, opt *DiffOptio
 	if d, err := app.emitDiff(ctx, opt, "permissions.json",
 		&jsondiff.Input{Name: "permissions", X: removes},
 		&jsondiff.Input{Name: "permissions", X: adds},
-		"",
+		"", nil,
 	); err != nil {
 		return hasDiff, err
 	} else if d {
@@ -266,7 +273,29 @@ func sortFunctionForDiff(fn *Function) {
 // ignore jq query) and renders it. When opt.External is set, the diff is shown
 // by running the external command against two temporary files instead of the
 // built-in colored unified diff. It returns true if there is any difference.
-func (app *App) emitDiff(ctx context.Context, opt *DiffOption, label string, from, to *jsondiff.Input, ignore string) (bool, error) {
+//
+// When maskSelectors is non-empty, ignore and then mask are applied to deep
+// copies of from.X / to.X before rendering, so every render path (built-in,
+// external temp files, and external command input) sees only masked values. A
+// single token registry is shared between the two sides so equal values
+// collapse to the same token. With no selectors the inputs are untouched.
+func (app *App) emitDiff(ctx context.Context, opt *DiffOption, label string, from, to *jsondiff.Input, ignore string, maskSelectors []string) (bool, error) {
+	if len(maskSelectors) > 0 {
+		reg := newMaskTokenRegistry()
+		fromMasked, err := maskInput(from.X, ignore, maskSelectors, reg)
+		if err != nil {
+			return false, err
+		}
+		toMasked, err := maskInput(to.X, ignore, maskSelectors, reg)
+		if err != nil {
+			return false, err
+		}
+		from = &jsondiff.Input{Name: from.Name, X: fromMasked}
+		to = &jsondiff.Input{Name: to.Name, X: toMasked}
+		// ignore has already been applied to the masked copies.
+		ignore = ""
+	}
+
 	var jsonOpts []jsondiff.Option
 	if ignore != "" {
 		p, err := gojq.Parse(ignore)

--- a/mask.go
+++ b/mask.go
@@ -1,0 +1,196 @@
+package lambroll
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/aereal/jsondiff"
+	"github.com/itchyny/gojq"
+)
+
+const (
+	maskTokenPrefix = "***MASKED#"
+	maskTokenSuffix = "***"
+)
+
+const (
+	envVarSelectorPrefix = `.Environment.Variables["`
+	envVarSelectorSuffix = `"]`
+)
+
+// maskFuncName is the name of the custom gojq function registered while masking.
+// It is distinctive to avoid colliding with anything in a user selector.
+const maskFuncName = "_lambroll_mask"
+
+// maskTokenRegistry maps each distinct canonical value to a stable token within
+// a single diff render. Equal values share a token (so an unchanged secret
+// produces no diff line); distinct values get distinct tokens (so a changed
+// secret still shows as a diff) without revealing the value.
+type maskTokenRegistry struct {
+	valueToToken map[string]string
+	next         int
+}
+
+func newMaskTokenRegistry() *maskTokenRegistry {
+	return &maskTokenRegistry{valueToToken: map[string]string{}, next: 1}
+}
+
+func (r *maskTokenRegistry) tokenFor(canonical string) string {
+	if tok, ok := r.valueToToken[canonical]; ok {
+		return tok
+	}
+	tok := fmt.Sprintf("%s%d%s", maskTokenPrefix, r.next, maskTokenSuffix)
+	r.valueToToken[canonical] = tok
+	r.next++
+	return tok
+}
+
+// resolveMaskSelector classifies a mask argument. An argument starting with "."
+// is used verbatim as a jq selector; otherwise it is a Lambda environment
+// variable name expanded to .Environment.Variables["<name>"]. A dotless argument
+// that looks like a selector (contains ".", "[" or "|") sets warn so a likely
+// mistyped selector is reported.
+func resolveMaskSelector(arg string) (selector string, warn bool) {
+	if strings.HasPrefix(arg, ".") {
+		return arg, false
+	}
+	warn = strings.ContainsAny(arg, ".[|")
+	return envVarSelectorPrefix + arg + envVarSelectorSuffix, warn
+}
+
+// resolveMaskSelectors resolves every mask argument to a jq selector, dropping
+// duplicates while preserving first-occurrence order.
+func resolveMaskSelectors(args []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		selector, warn := resolveMaskSelector(arg)
+		if warn {
+			slog.Warn("mask argument looks like a selector but does not start with '.'; treating it as an environment variable name", "argument", arg, "resolved", selector)
+		}
+		if _, ok := seen[selector]; ok {
+			continue
+		}
+		seen[selector] = struct{}{}
+		out = append(out, selector)
+	}
+	return out
+}
+
+// canonicalize reduces a matched value to a stable string used as the registry
+// key, so structurally-equal values collapse to the same token. json.Marshal
+// sorts object keys, so equal values always produce the same key.
+func canonicalize(value any) (string, error) {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("failed to canonicalize masked value: %w", err)
+	}
+	return string(b), nil
+}
+
+// applyMask replaces every value matched by the selectors with a token. Each
+// selector is run as an update assignment of the form
+//
+//	(<selector> | select(. != null)) |= _lambroll_mask
+//
+// so only existing (non-null) values are replaced. A selector pointing at an
+// absent path therefore neither creates that path (which would otherwise appear
+// as a spurious diff and fabricate a field on the side that lacks it) nor
+// errors. A selector that matches nothing warns and is a no-op; a selector that
+// iterates an absent node (e.g. ".Environment.Variables[]" on a function with
+// no Environment) is also a no-op; any other evaluation error is returned so an
+// invalid selector fails loudly instead of leaving a value unmasked. gojq does
+// not mutate its input; the updated document is returned.
+func applyMask(root any, selectors []string, reg *maskTokenRegistry) (any, error) {
+	for _, selector := range selectors {
+		query, err := gojq.Parse("(" + selector + " | select(. != null)) |= " + maskFuncName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse mask selector %q: %w", selector, err)
+		}
+		matched := 0
+		var maskErr error
+		code, err := gojq.Compile(query, gojq.WithFunction(maskFuncName, 0, 0, func(in any, _ []any) any {
+			canonical, err := canonicalize(in)
+			if err != nil {
+				if maskErr == nil {
+					maskErr = err
+				}
+				return in
+			}
+			matched++
+			return reg.tokenFor(canonical)
+		}))
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile mask selector %q: %w", selector, err)
+		}
+		v, ok := code.Run(root).Next()
+		if !ok {
+			return nil, fmt.Errorf("mask selector %q produced no result", selector)
+		}
+		if err, isErr := v.(error); isErr {
+			if isNullIterationError(err) {
+				slog.Warn("mask selector matched nothing", "selector", selector)
+				continue
+			}
+			return nil, fmt.Errorf("failed to apply mask selector %q: %w", selector, err)
+		}
+		if maskErr != nil {
+			return nil, fmt.Errorf("failed to apply mask selector %q: %w", selector, maskErr)
+		}
+		root = v
+		if matched == 0 {
+			slog.Warn("mask selector matched nothing", "selector", selector)
+		}
+	}
+	return root, nil
+}
+
+// isNullIterationError reports whether err is gojq's "cannot iterate over: null"
+// error, raised when a "[]" selector iterates an absent/null node. The message
+// is matched literally because gojq's iteratorError type is unexported; gojq is
+// version-pinned in go.mod and TestApplyMaskAbsentIterable guards this.
+func isNullIterationError(err error) bool {
+	return err != nil && err.Error() == "cannot iterate over: null"
+}
+
+// deepCopyJSONValue returns a deep copy of a JSON-decoded value via a round-trip,
+// so masking never mutates the original local definition or remote configuration.
+func deepCopyJSONValue(x any) (any, error) {
+	b, err := json.Marshal(x)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deep-copy value for masking: %w", err)
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, fmt.Errorf("failed to deep-copy value for masking: %w", err)
+	}
+	return out, nil
+}
+
+// maskInput returns x with the ignore query and then the mask selectors applied
+// to a deep copy, so the original value is never mutated. With no selectors it
+// returns x unchanged. The returned value already has ignore applied, so callers
+// must not apply ignore again.
+func maskInput(x any, ignore string, selectors []string, reg *maskTokenRegistry) (any, error) {
+	if len(selectors) == 0 {
+		return x, nil
+	}
+	copied, err := deepCopyJSONValue(x)
+	if err != nil {
+		return nil, err
+	}
+	if ignore != "" {
+		q, err := gojq.Parse("del(" + ignore + ")")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ignore query: %s %w", ignore, err)
+		}
+		modified, err := jsondiff.ModifyValue(q, copied)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply ignore query: %w", err)
+		}
+		copied = modified
+	}
+	return applyMask(copied, selectors, reg)
+}

--- a/mask.go
+++ b/mask.go
@@ -172,6 +172,14 @@ func deepCopyJSONValue(x any) (any, error) {
 	return out, nil
 }
 
+// maskValue applies the mask selectors to a deep copy of v using a fresh token
+// registry. It is the single-document counterpart of the diff masking (used by
+// render), where there is no second side to keep token-consistent. With no
+// selectors v is returned unchanged.
+func maskValue(v any, selectors []string) (any, error) {
+	return maskInput(v, "", selectors, newMaskTokenRegistry())
+}
+
 // maskInput returns x with the ignore query and then the mask selectors applied
 // to a deep copy, so the original value is never mutated. With no selectors it
 // returns x unchanged. The returned value already has ignore applied, so callers

--- a/mask.go
+++ b/mask.go
@@ -15,10 +15,9 @@ const (
 	maskTokenSuffix = "***"
 )
 
-const (
-	envVarSelectorPrefix = `.Environment.Variables["`
-	envVarSelectorSuffix = `"]`
-)
+// envVarSelectorBase is the path to the Lambda environment variable map; an
+// environment-variable-name mask argument is expanded to a subscript of it.
+const envVarSelectorBase = ".Environment.Variables"
 
 // maskFuncName is the name of the custom gojq function registered while masking.
 // It is distinctive to avoid colliding with anything in a user selector.
@@ -57,7 +56,11 @@ func resolveMaskSelector(arg string) (selector string, warn bool) {
 		return arg, false
 	}
 	warn = strings.ContainsAny(arg, ".[|")
-	return envVarSelectorPrefix + arg + envVarSelectorSuffix, warn
+	// Encode the name as a JSON string literal (which is valid jq) so a name
+	// containing " or \ cannot break out of the subscript. json.Marshal of a
+	// string never fails.
+	key, _ := json.Marshal(arg)
+	return envVarSelectorBase + "[" + string(key) + "]", warn
 }
 
 // resolveMaskSelectors resolves every mask argument to a jq selector, dropping

--- a/mask_test.go
+++ b/mask_test.go
@@ -1,0 +1,271 @@
+package lambroll
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aereal/jsondiff"
+)
+
+func mustJSON(t *testing.T, s string) any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		t.Fatalf("invalid json %q: %v", s, err)
+	}
+	return v
+}
+
+func dumpJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestResolveMaskSelector(t *testing.T) {
+	cases := []struct {
+		arg      string
+		selector string
+		warn     bool
+	}{
+		{"DB_PASSWORD", `.Environment.Variables["DB_PASSWORD"]`, false},
+		{".Environment.Variables[]", ".Environment.Variables[]", false},
+		{".Foo.Bar", ".Foo.Bar", false},
+		{"looks.like.selector", `.Environment.Variables["looks.like.selector"]`, true},
+		{"has[bracket]", `.Environment.Variables["has[bracket]"]`, true},
+	}
+	for _, c := range cases {
+		sel, warn := resolveMaskSelector(c.arg)
+		if sel != c.selector || warn != c.warn {
+			t.Errorf("resolveMaskSelector(%q) = (%q, %v), want (%q, %v)", c.arg, sel, warn, c.selector, c.warn)
+		}
+	}
+}
+
+func TestResolveMaskSelectorsDedup(t *testing.T) {
+	got := resolveMaskSelectors([]string{
+		"DB_PASSWORD",
+		".Environment.Variables[]",
+		"DB_PASSWORD", // dup of the first (same resolved selector)
+		".Environment.Variables[]",
+	})
+	want := []string{`.Environment.Variables["DB_PASSWORD"]`, ".Environment.Variables[]"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("resolveMaskSelectors dedup = %v, want %v", got, want)
+	}
+}
+
+func TestMaskTokenRegistry(t *testing.T) {
+	r := newMaskTokenRegistry()
+	a1 := r.tokenFor(`"secret"`)
+	a2 := r.tokenFor(`"secret"`) // same value -> same token
+	b := r.tokenFor(`"other"`)   // different value -> different token
+	if a1 != a2 {
+		t.Errorf("equal values got different tokens: %q vs %q", a1, a2)
+	}
+	if a1 == b {
+		t.Errorf("distinct values share a token: %q", a1)
+	}
+	if a1 != "***MASKED#1***" || b != "***MASKED#2***" {
+		t.Errorf("unexpected tokens: %q %q", a1, b)
+	}
+}
+
+func TestCanonicalizeKeyOrderIndependent(t *testing.T) {
+	x := mustJSON(t, `{"b":1,"a":2}`)
+	y := mustJSON(t, `{"a":2,"b":1}`)
+	cx, _ := canonicalize(x)
+	cy, _ := canonicalize(y)
+	if cx != cy {
+		t.Errorf("structurally-equal values canonicalized differently: %q vs %q", cx, cy)
+	}
+}
+
+func TestApplyMaskEnvVar(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	root := mustJSON(t, `{"Environment":{"Variables":{"A":"1","B":"2"}}}`)
+	got, err := applyMask(root, []string{`.Environment.Variables["A"]`}, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"Environment":{"Variables":{"A":"***MASKED#1***","B":"2"}}}`
+	if dumpJSON(t, got) != want {
+		t.Errorf("applyMask = %s, want %s", dumpJSON(t, got), want)
+	}
+}
+
+// TestApplyMaskDrift verifies the drift-visibility contract: equal values across
+// two renders share a token (no diff), distinct values get distinct tokens.
+func TestApplyMaskDrift(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	sel := []string{".Environment.Variables[]"}
+
+	remote, err := applyMask(mustJSON(t, `{"Environment":{"Variables":{"SAME":"x","CHANGED":"old"}}}`), sel, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	local, err := applyMask(mustJSON(t, `{"Environment":{"Variables":{"SAME":"x","CHANGED":"new"}}}`), sel, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rv := remote.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)
+	lv := local.(map[string]any)["Environment"].(map[string]any)["Variables"].(map[string]any)
+
+	if rv["SAME"] != lv["SAME"] {
+		t.Errorf("equal value got different tokens: %v vs %v", rv["SAME"], lv["SAME"])
+	}
+	if rv["CHANGED"] == lv["CHANGED"] {
+		t.Errorf("changed value shares a token: %v", rv["CHANGED"])
+	}
+	for _, v := range []any{rv["SAME"], rv["CHANGED"], lv["SAME"], lv["CHANGED"]} {
+		if s, _ := v.(string); s == "x" || s == "old" || s == "new" {
+			t.Errorf("plaintext value leaked: %v", v)
+		}
+	}
+}
+
+// TestApplyMaskAbsentLiteralKey guards the core correctness property: a selector
+// pointing at an absent path must NOT create that path (which would fabricate a
+// field and show as a spurious diff).
+func TestApplyMaskAbsentLiteralKey(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	root := mustJSON(t, `{"FunctionName":"x"}`)
+	got, err := applyMask(root, []string{`.Environment.Variables["A"]`}, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dumpJSON(t, got) != `{"FunctionName":"x"}` {
+		t.Errorf("absent key was created: %s", dumpJSON(t, got))
+	}
+}
+
+// TestApplyMaskAbsentIterable guards isNullIterationError: iterating an absent
+// node is a no-op, not an error and not a created field.
+func TestApplyMaskAbsentIterable(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	root := mustJSON(t, `{"FunctionName":"x"}`)
+	got, err := applyMask(root, []string{".Environment.Variables[]"}, reg)
+	if err != nil {
+		t.Fatalf("absent iterable should be a no-op, got error: %v", err)
+	}
+	if dumpJSON(t, got) != `{"FunctionName":"x"}` {
+		t.Errorf("absent iterable mutated the document: %s", dumpJSON(t, got))
+	}
+}
+
+// TestApplyMaskNullValueSkipped verifies a present null value is left untouched
+// (null is not sensitive and select(. != null) skips it).
+func TestApplyMaskNullValueSkipped(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	root := mustJSON(t, `{"Environment":{"Variables":{"A":null,"B":"2"}}}`)
+	got, err := applyMask(root, []string{".Environment.Variables[]"}, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"Environment":{"Variables":{"A":null,"B":"***MASKED#1***"}}}`
+	if dumpJSON(t, got) != want {
+		t.Errorf("applyMask = %s, want %s", dumpJSON(t, got), want)
+	}
+}
+
+func TestApplyMaskRoot(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	root := mustJSON(t, `{"a":1}`)
+	got, err := applyMask(root, []string{"."}, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "***MASKED#1***" {
+		t.Errorf("root selector should collapse whole doc to one token, got %v", got)
+	}
+}
+
+func TestApplyMaskInvalidSelectorErrors(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	root := mustJSON(t, `{"a":1}`)
+	if _, err := applyMask(root, []string{".a["}, reg); err == nil {
+		t.Error("expected error for invalid selector")
+	}
+}
+
+func TestMaskInputNoSelectorsUntouched(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	x := mustJSON(t, `{"a":1}`)
+	got, err := maskInput(x, "", nil, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// same underlying value returned unchanged
+	if dumpJSON(t, got) != `{"a":1}` {
+		t.Errorf("maskInput with no selectors changed the value: %s", dumpJSON(t, got))
+	}
+}
+
+// TestEmitDiffMaskedRendersTokens verifies the full render path: a changed
+// secret shows as a diff with tokens, and the plaintext never appears.
+func TestEmitDiffMaskedRendersTokens(t *testing.T) {
+	var buf bytes.Buffer
+	opt := &DiffOption{w: &buf}
+	app := &App{}
+	from := &jsondiff.Input{Name: "remote", X: mustJSON(t, `{"Environment":{"Variables":{"DB_PASSWORD":"old-secret"}}}`)}
+	to := &jsondiff.Input{Name: "local", X: mustJSON(t, `{"Environment":{"Variables":{"DB_PASSWORD":"new-secret"}}}`)}
+
+	hasDiff, err := app.emitDiff(context.Background(), opt, "function.json", from, to, "", resolveMaskSelectors([]string{"DB_PASSWORD"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasDiff {
+		t.Fatal("expected a diff for a changed secret")
+	}
+	out := buf.String()
+	if strings.Contains(out, "old-secret") || strings.Contains(out, "new-secret") {
+		t.Errorf("plaintext secret leaked into diff output:\n%s", out)
+	}
+	if !strings.Contains(out, maskTokenPrefix) {
+		t.Errorf("expected mask token in output:\n%s", out)
+	}
+}
+
+// TestEmitDiffMaskedUnchangedNoDiff verifies an unchanged secret produces no
+// diff (equal values share a token on both sides).
+func TestEmitDiffMaskedUnchangedNoDiff(t *testing.T) {
+	var buf bytes.Buffer
+	opt := &DiffOption{w: &buf}
+	app := &App{}
+	doc := `{"Environment":{"Variables":{"DB_PASSWORD":"same-secret","OTHER":"v"}}}`
+	from := &jsondiff.Input{Name: "remote", X: mustJSON(t, doc)}
+	to := &jsondiff.Input{Name: "local", X: mustJSON(t, doc)}
+
+	hasDiff, err := app.emitDiff(context.Background(), opt, "function.json", from, to, "", resolveMaskSelectors([]string{"DB_PASSWORD"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasDiff {
+		t.Errorf("expected no diff for an unchanged secret, got:\n%s", buf.String())
+	}
+}
+
+func TestMaskInputAppliesIgnoreThenMask(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	x := mustJSON(t, `{"Environment":{"Variables":{"A":"1"}},"Drop":"me"}`)
+	got, err := maskInput(x, ".Drop", []string{`.Environment.Variables["A"]`}, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"Environment":{"Variables":{"A":"***MASKED#1***"}}}`
+	if dumpJSON(t, got) != want {
+		t.Errorf("maskInput = %s, want %s", dumpJSON(t, got), want)
+	}
+	// original must be untouched (deep copy)
+	if dumpJSON(t, x) != `{"Drop":"me","Environment":{"Variables":{"A":"1"}}}` {
+		t.Errorf("maskInput mutated the original: %s", dumpJSON(t, x))
+	}
+}

--- a/mask_test.go
+++ b/mask_test.go
@@ -40,6 +40,8 @@ func TestResolveMaskSelector(t *testing.T) {
 		{".Foo.Bar", ".Foo.Bar", false},
 		{"looks.like.selector", `.Environment.Variables["looks.like.selector"]`, true},
 		{"has[bracket]", `.Environment.Variables["has[bracket]"]`, true},
+		// a name containing " must be JSON-escaped so it cannot break the subscript
+		{`a"b`, `.Environment.Variables["a\"b"]`, false},
 	}
 	for _, c := range cases {
 		sel, warn := resolveMaskSelector(c.arg)
@@ -96,6 +98,22 @@ func TestApplyMaskEnvVar(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := `{"Environment":{"Variables":{"A":"***MASKED#1***","B":"2"}}}`
+	if dumpJSON(t, got) != want {
+		t.Errorf("applyMask = %s, want %s", dumpJSON(t, got), want)
+	}
+}
+
+// TestApplyMaskEnvVarNameWithQuote verifies a name containing " is escaped so
+// the generated selector still targets exactly that key (and does not break).
+func TestApplyMaskEnvVarNameWithQuote(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	root := mustJSON(t, `{"Environment":{"Variables":{"a\"b":"secret","c":"keep"}}}`)
+	sel, _ := resolveMaskSelector(`a"b`)
+	got, err := applyMask(root, []string{sel}, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"Environment":{"Variables":{"a\"b":"***MASKED#1***","c":"keep"}}}`
 	if dumpJSON(t, got) != want {
 		t.Errorf("applyMask = %s, want %s", dumpJSON(t, got), want)
 	}

--- a/mask_test.go
+++ b/mask_test.go
@@ -271,6 +271,44 @@ func TestEmitDiffMaskedUnchangedNoDiff(t *testing.T) {
 	}
 }
 
+// TestRenderDefinitionMask verifies render-style single-document masking:
+// matched values become tokens, others are preserved, and plaintext never
+// appears.
+func TestRenderDefinitionMask(t *testing.T) {
+	def := mustJSON(t, `{"FunctionName":"f","Environment":{"Variables":{"DB_PASSWORD":"secret","PUBLIC":"ok"}}}`)
+	b, err := renderDefinition(def, resolveMaskSelectors([]string{"DB_PASSWORD"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if strings.Contains(s, "secret") {
+		t.Errorf("plaintext leaked into render output:\n%s", s)
+	}
+	if !strings.Contains(s, maskTokenPrefix) {
+		t.Errorf("expected mask token in render output:\n%s", s)
+	}
+	if !strings.Contains(s, `"PUBLIC": "ok"`) {
+		t.Errorf("non-masked value not preserved:\n%s", s)
+	}
+}
+
+// TestRenderDefinitionNoMaskIdentical verifies that without selectors the output
+// is byte-identical to the unmasked marshaling.
+func TestRenderDefinitionNoMaskIdentical(t *testing.T) {
+	def := mustJSON(t, `{"FunctionName":"f","Environment":{"Variables":{"DB_PASSWORD":"secret"}}}`)
+	got, err := renderDefinition(def, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := marshalJSON(def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("renderDefinition with no mask differs from marshalJSON:\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
 func TestMaskInputAppliesIgnoreThenMask(t *testing.T) {
 	reg := newMaskTokenRegistry()
 	x := mustJSON(t, `{"Environment":{"Variables":{"A":"1"}},"Drop":"me"}`)

--- a/optionfile_test.go
+++ b/optionfile_test.go
@@ -143,10 +143,17 @@ func TestUnmarshalJSONStrict(t *testing.T) {
 			t.Error("expected error for unknown nested key")
 		}
 	})
-	t.Run("removed extstr/extcode aliases", func(t *testing.T) {
+	t.Run("deprecated extstr/extcode aliases accepted", func(t *testing.T) {
 		var c CLIOptions
-		if err := unmarshalJSON([]byte(`{"extstr":{"a":"b"}}`), &c, "test"); err == nil {
-			t.Error("expected error for removed extstr alias")
+		if err := unmarshalJSON([]byte(`{"extstr":{"a":"b"},"extcode":{"c":"d"}}`), &c, "test"); err != nil {
+			t.Errorf("deprecated extstr/extcode aliases should be accepted: %v", err)
+		}
+		c.applyLegacyExtVars()
+		if c.ExtStr["a"] != "b" {
+			t.Errorf("extstr should be folded into ExtStr: %v", c.ExtStr)
+		}
+		if c.ExtCode["c"] != "d" {
+			t.Errorf("extcode should be folded into ExtCode: %v", c.ExtCode)
 		}
 	})
 	t.Run("non-strict type warns and continues", func(t *testing.T) {

--- a/render.go
+++ b/render.go
@@ -2,13 +2,15 @@ package lambroll
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 )
 
 type RenderOption struct {
-	Jsonnet     bool   `default:"false" help:"render function.json as jsonnet" json:"jsonnet,omitempty"`
-	FunctionURL string `help:"render function-url definition file" default:"" env:"LAMBROLL_FUNCTION_URL" json:"function_url,omitempty"`
+	Jsonnet     bool     `default:"false" help:"render function.json as jsonnet" json:"jsonnet,omitempty"`
+	FunctionURL string   `help:"render function-url definition file" default:"" env:"LAMBROLL_FUNCTION_URL" json:"function_url,omitempty"`
+	Mask        []string `help:"mask values in rendered output by jq selector or environment variable name (repeatable)" json:"mask,omitempty"`
 }
 
 // Invoke invokes function
@@ -17,18 +19,19 @@ func (app *App) Render(ctx context.Context, opt *RenderOption) error {
 	if err != nil {
 		return fmt.Errorf("failed to load function: %w", err)
 	}
+	maskSelectors := resolveMaskSelectors(opt.Mask)
 	var b []byte
 	if opt.FunctionURL != "" {
 		fu, err := app.loadFunctionUrl(opt.FunctionURL, *fn.FunctionName)
 		if err != nil {
 			return fmt.Errorf("failed to load function-url: %w", err)
 		}
-		b, err = marshalJSON(fu)
+		b, err = renderDefinition(fu, maskSelectors)
 		if err != nil {
 			return fmt.Errorf("failed to marshal function-url: %w", err)
 		}
 	} else {
-		b, err = marshalJSON(fn)
+		b, err = renderDefinition(fn, maskSelectors)
 		if err != nil {
 			return fmt.Errorf("failed to marshal function: %w", err)
 		}
@@ -44,4 +47,26 @@ func (app *App) Render(ctx context.Context, opt *RenderOption) error {
 		return fmt.Errorf("failed to write function.json: %w", err)
 	}
 	return nil
+}
+
+// renderDefinition marshals a definition to indented JSON. When mask selectors
+// are given, matched values are replaced with tokens first. With no selectors
+// the output is byte-identical to marshalJSON.
+func renderDefinition(s any, maskSelectors []string) ([]byte, error) {
+	if len(maskSelectors) == 0 {
+		return marshalJSON(s)
+	}
+	v, err := marshalAny(s)
+	if err != nil {
+		return nil, err
+	}
+	masked, err := maskValue(v, maskSelectors)
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.MarshalIndent(masked, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
 }

--- a/test/cli/diff_mask.jsonnet
+++ b/test/cli/diff_mask.jsonnet
@@ -1,0 +1,5 @@
+{
+  diff: {
+    mask: ['DB_PASSWORD', '.Environment.Variables[]'],
+  },
+}

--- a/test/cli/ext_vars_legacy.jsonnet
+++ b/test/cli/ext_vars_legacy.jsonnet
@@ -1,0 +1,12 @@
+{
+  // deprecated key names (lambroll <= v1.3.1); must still be accepted.
+  extstr: {
+    architecture: "x86_64",
+    description: "Test function with ext_str and ext_code",
+  },
+  extcode: {
+    memory_size: "128",
+    storage_size: "512",
+    timeout: "30",
+  },
+}

--- a/test/cli/render_mask.jsonnet
+++ b/test/cli/render_mask.jsonnet
@@ -1,0 +1,5 @@
+{
+  render: {
+    mask: ['DB_PASSWORD'],
+  },
+}


### PR DESCRIPTION
Reworks #613 (by @ijin) on top of `pre-v2`, and extends masking to `render`.

## What

`--mask` hides resolved secret values while keeping the field visible, so they are not accidentally leaked. Display-only; `deploy` is unchanged.

- **`lambroll diff --mask`**: equal values share a per-run token `***MASKED#<n>***` (unchanged → no diff line), changed values differ, so drift stays visible without printing the plaintext.
- **`lambroll render --mask`**: replaces matched values with tokens in the rendered definition (which has `ssm(...)` etc. expanded to plaintext), so it can be shared/inspected safely.
- `--mask DB_PASSWORD` masks an environment variable by name; `--mask '.Environment.Variables[]'` (a `.`-prefixed argument) is a jq selector that can target any field. Repeatable.
- Defaults via the option file under `diff.mask` / `render.mask`; a CLI `--mask` replaces the configured list.

## Why this differs from #613

- **Built on the unified `CLIOptions` option-file mechanism** (merged to `pre-v2`): `diff.mask` / `render.mask` are just `json`-tagged fields resolved by the shared resolver, so the ad-hoc `DiffMaskOption` / `Option.Diff` / manual merge in `ParseCLI` are gone.
- **Masking is a single gojq update** `(<selector> | select(. != null)) |= _mask`. `select(. != null)` guarantees a selector pointing at an absent path neither creates that path (which would fabricate a field and surface as a spurious diff) nor errors. This removes the hand-rolled path walkers (~120 lines) and their edge cases. Non-test code is ~37% smaller than #613.
- The masking core is command-agnostic and reused by both `diff` and `render`; an environment variable name is JSON-encoded into the selector so a name containing `"` cannot break it.

Masking covers only the function configuration diff (not CodeSha256/function-url/permissions) and every render path; with no `--mask` the output is byte-identical to before.

## Restore extstr/extcode compatibility

The strict `CLIOptions` loader rejected the pre-v1.3.1 option file keys `extstr` / `extcode` as unknown fields — an unnecessary breaking change. They are accepted again via kong-ignored `LegacyExtStr` / `LegacyExtCode` fields folded into `ExtStr` / `ExtCode` with a deprecation warning, so old option files keep working on v1 without forcing a v2.
