### PR TITLE
Fix diff/render of empty environment variables and mask warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 .envrc
 cmd/lambroll/lambroll
 dist/
+
+# Editor and AI tool settings
+.claude/
+.codex/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ $ lambroll diff --exit-code   # Exit with code 2 if differences exist
 
 Use `--ignore` with jq query syntax to ignore specific fields when comparing.
 
+lambroll omits empty fields (null, `false`, empty objects/arrays, and empty strings) from the diff and render output. Environment variable values are the exception: an empty string value inside `Environment.Variables` is kept, because lambroll deploys it to AWS as-is (an empty variable is distinct from an unset one for `os.LookupEnv` and similar). To stop managing environment variables instead of setting them empty, exclude them with `--ignore '.Environment'`.
+
 `lambroll diff --external` can render the diff with an external command of your choice. lambroll writes the remote and local definitions to temporary files and invokes the command with those two file paths as the last two arguments. The fields removed by `--ignore` are also removed from the files passed to the external command.
 
 For example, use [difftastic](https://github.com/Wilfred/difftastic) (`difft`).
@@ -736,8 +738,6 @@ function.json is a definition for Lambda function. JSON structure is based from 
 The template functions is available in `{{ }}`.
 - `env` function expands environment variables.
 - `must_env` function expands environment variables. If the environment variable is not defined, lambroll will panic and abort.
-
-lambroll omits empty fields (null, `false`, empty objects/arrays, and empty strings) from the definition shown by `diff` and `render`. Environment variable values are the exception: an empty string value inside `Environment.Variables` is kept, because lambroll deploys it to AWS as-is (an empty variable is distinct from an unset one for `os.LookupEnv` and similar). To stop managing environment variables instead of setting them empty, exclude them with `--ignore '.Environment'`.
 
 ### Tags
 

--- a/README.md
+++ b/README.md
@@ -737,6 +737,8 @@ The template functions is available in `{{ }}`.
 - `env` function expands environment variables.
 - `must_env` function expands environment variables. If the environment variable is not defined, lambroll will panic and abort.
 
+lambroll omits empty fields (null, `false`, empty objects/arrays, and empty strings) from the definition shown by `diff` and `render`. Environment variable values are the exception: an empty string value inside `Environment.Variables` is kept, because lambroll deploys it to AWS as-is (an empty variable is distinct from an unset one for `os.LookupEnv` and similar). To stop managing environment variables instead of setting them empty, exclude them with `--ignore '.Environment'`.
+
 ### Tags
 
 When "Tags" key exists in function.json, lambroll set / remove tags to the lambda function at deploy.

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ Each distinct value is replaced with a per-run token `***MASKED#<n>***`. Equal v
    }
 ```
 
-Masking applies only to the function configuration diff (not the CodeSha256, function URL, or permissions diffs) and to every render path (built-in diff and `--external`). A selector that matches nothing (including one that points at an absent field) warns and is a no-op without fabricating a field; an invalid selector errors. Defaults can be set in the option file under `diff.mask`; a `--mask` flag on the command line replaces the configured list.
+Masking applies only to the function configuration diff (not the CodeSha256, function URL, or permissions diffs) and to every render path (built-in diff and `--external`). A selector that matches nothing is a no-op and does not fabricate a field; an invalid selector errors. In a diff a selector is reported as matching nothing (and warns) only when it matches on neither side, so masking a field that is present on one side but empty or absent on the other (an empty `Description`, for example) does not warn. Defaults can be set in the option file under `diff.mask`; a `--mask` flag on the command line replaces the configured list.
 
 ```jsonnet
 {

--- a/diff.go
+++ b/diff.go
@@ -290,6 +290,10 @@ func (app *App) emitDiff(ctx context.Context, opt *DiffOption, label string, fro
 		if err != nil {
 			return false, err
 		}
+		// Warn only for selectors that matched nothing on either side, so a
+		// selector masking a value present on just one side (or a field that is
+		// empty/omitted on one side) is not reported as a no-op.
+		reg.warnUnmatched(maskSelectors)
 		from = &jsondiff.Input{Name: from.Name, X: fromMasked}
 		to = &jsondiff.Input{Name: to.Name, X: toMasked}
 		// ignore has already been applied to the masked copies.

--- a/json.go
+++ b/json.go
@@ -23,11 +23,31 @@ func isEmptyValue(value any) bool {
 }
 
 func omitEmptyValues(data any) any {
+	return omitEmptyValuesIn(data, "", false)
+}
+
+// omitEmptyValuesIn removes empty values recursively. parentKey is the key under
+// which data sits in its parent map (empty for the root). keepEmptyStr is true
+// while processing the Environment.Variables map: there, string values are kept
+// even when empty, because an intentionally-empty environment variable is
+// deployed to AWS as-is and dropping it would hide it from diff/render output.
+// All other empty values (null, false, empty objects/arrays, and empty strings
+// outside Environment.Variables) are still dropped everywhere.
+func omitEmptyValuesIn(data any, parentKey string, keepEmptyStr bool) any {
 	switch v := data.(type) {
 	case map[string]any:
 		nonEmptyMap := make(map[string]any)
 		for key, value := range v {
-			nonEmptyValue := omitEmptyValues(value)
+			// Inside Environment.Variables, keep string values verbatim so an
+			// empty environment variable survives.
+			if keepEmptyStr {
+				if s, ok := value.(string); ok {
+					nonEmptyMap[key] = s
+					continue
+				}
+			}
+			inEnvVars := parentKey == "Environment" && key == "Variables"
+			nonEmptyValue := omitEmptyValuesIn(value, key, inEnvVars)
 			if !isEmptyValue(nonEmptyValue) {
 				nonEmptyMap[key] = nonEmptyValue
 			}
@@ -38,7 +58,7 @@ func omitEmptyValues(data any) any {
 	case []any:
 		nonEmptyList := make([]any, 0)
 		for _, value := range v {
-			nonEmptyValue := omitEmptyValues(value)
+			nonEmptyValue := omitEmptyValuesIn(value, "", false)
 			if !isEmptyValue(nonEmptyValue) {
 				nonEmptyList = append(nonEmptyList, nonEmptyValue)
 			}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,73 @@
+package lambroll
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func mustUnmarshal(t *testing.T, s string) any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		t.Fatalf("invalid json %q: %v", s, err)
+	}
+	return v
+}
+
+// TestOmitEmptyValuesKeepsEnvVars verifies that empty string values inside
+// Environment.Variables are preserved (an intentionally-empty environment
+// variable is deployed to AWS as-is), while empty values elsewhere are dropped.
+func TestOmitEmptyValuesKeepsEnvVars(t *testing.T) {
+	in := mustUnmarshal(t, `{
+		"FunctionName": "f",
+		"Description": "",
+		"Environment": {"Variables": {"FILLED": "x", "EMPTY": ""}}
+	}`)
+	got := omitEmptyValues(in)
+	want := mustUnmarshal(t, `{
+		"FunctionName": "f",
+		"Environment": {"Variables": {"FILLED": "x", "EMPTY": ""}}
+	}`)
+	if !reflect.DeepEqual(got, want) {
+		b, _ := json.Marshal(got)
+		t.Errorf("omitEmptyValues = %s, want EMPTY env var kept and empty Description dropped", b)
+	}
+}
+
+// TestOmitEmptyValuesAllEmptyEnvVars verifies that a Variables map containing
+// only empty strings is kept (not collapsed away), so the env var stays visible.
+func TestOmitEmptyValuesAllEmptyEnvVars(t *testing.T) {
+	in := mustUnmarshal(t, `{"Environment": {"Variables": {"EMPTY": ""}}}`)
+	got := omitEmptyValues(in)
+	want := mustUnmarshal(t, `{"Environment": {"Variables": {"EMPTY": ""}}}`)
+	if !reflect.DeepEqual(got, want) {
+		b, _ := json.Marshal(got)
+		t.Errorf("omitEmptyValues = %s, want the empty env var preserved", b)
+	}
+}
+
+// TestOmitEmptyValuesEmptyStringOutsideEnvVars verifies the scoping: an empty
+// string under a key named "Variables" that is NOT under Environment is still
+// dropped, so the env var exception does not leak to unrelated fields.
+func TestOmitEmptyValuesEmptyStringOutsideEnvVars(t *testing.T) {
+	in := mustUnmarshal(t, `{"Other": {"Variables": {"K": ""}}}`)
+	got := omitEmptyValues(in)
+	if got != nil {
+		b, _ := json.Marshal(got)
+		t.Errorf("omitEmptyValues = %s, want empty string outside Environment.Variables dropped (nil)", b)
+	}
+}
+
+// TestOmitEmptyValuesDropsOtherEmptiesInEnvVars verifies that within
+// Environment.Variables only string values are kept; a null value (not a valid
+// env var value, but defensive) is still dropped.
+func TestOmitEmptyValuesDropsNullInEnvVars(t *testing.T) {
+	in := mustUnmarshal(t, `{"Environment": {"Variables": {"NULL": null, "EMPTY": ""}}}`)
+	got := omitEmptyValues(in)
+	want := mustUnmarshal(t, `{"Environment": {"Variables": {"EMPTY": ""}}}`)
+	if !reflect.DeepEqual(got, want) {
+		b, _ := json.Marshal(got)
+		t.Errorf("omitEmptyValues = %s, want null dropped and empty string kept", b)
+	}
+}

--- a/mask.go
+++ b/mask.go
@@ -27,13 +27,38 @@ const maskFuncName = "_lambroll_mask"
 // a single diff render. Equal values share a token (so an unchanged secret
 // produces no diff line); distinct values get distinct tokens (so a changed
 // secret still shows as a diff) without revealing the value.
+//
+// It also accumulates how many values each selector matched. The registry's
+// lifetime matches the warning scope: in a diff a single registry is shared by
+// both sides, so matched aggregates the remote and local counts and a selector
+// is reported as matching nothing only when it matched on neither side; in
+// render a fresh registry covers the single document.
 type maskTokenRegistry struct {
 	valueToToken map[string]string
 	next         int
+	matched      map[string]int
 }
 
 func newMaskTokenRegistry() *maskTokenRegistry {
-	return &maskTokenRegistry{valueToToken: map[string]string{}, next: 1}
+	return &maskTokenRegistry{valueToToken: map[string]string{}, next: 1, matched: map[string]int{}}
+}
+
+// recordMatch accumulates the number of values a selector matched. Recording a
+// zero count still registers the selector so warnUnmatched can report it.
+func (r *maskTokenRegistry) recordMatch(selector string, n int) {
+	r.matched[selector] += n
+}
+
+// warnUnmatched logs a warning for every selector that matched no value across
+// all documents masked with this registry, which typically indicates a mistyped
+// selector. A selector that matched only an empty/absent field (omitted from the
+// marshaled document) on every side is also reported here.
+func (r *maskTokenRegistry) warnUnmatched(selectors []string) {
+	for _, selector := range selectors {
+		if r.matched[selector] == 0 {
+			slog.Warn("mask selector matched nothing", "selector", selector)
+		}
+	}
 }
 
 func (r *maskTokenRegistry) tokenFor(canonical string) string {
@@ -101,11 +126,14 @@ func canonicalize(value any) (string, error) {
 // so only existing (non-null) values are replaced. A selector pointing at an
 // absent path therefore neither creates that path (which would otherwise appear
 // as a spurious diff and fabricate a field on the side that lacks it) nor
-// errors. A selector that matches nothing warns and is a no-op; a selector that
-// iterates an absent node (e.g. ".Environment.Variables[]" on a function with
-// no Environment) is also a no-op; any other evaluation error is returned so an
+// errors. A selector that matches nothing is a no-op; a selector that iterates
+// an absent node (e.g. ".Environment.Variables[]" on a function with no
+// Environment) is also a no-op; any other evaluation error is returned so an
 // invalid selector fails loudly instead of leaving a value unmasked. gojq does
-// not mutate its input; the updated document is returned.
+// not mutate its input; the updated document is returned. The number of values
+// each selector matched is recorded in reg so the caller can warn once a
+// selector has matched nothing across every document it masked (see
+// maskTokenRegistry.warnUnmatched).
 func applyMask(root any, selectors []string, reg *maskTokenRegistry) (any, error) {
 	for _, selector := range selectors {
 		query, err := gojq.Parse("(" + selector + " | select(. != null)) |= " + maskFuncName)
@@ -134,7 +162,7 @@ func applyMask(root any, selectors []string, reg *maskTokenRegistry) (any, error
 		}
 		if err, isErr := v.(error); isErr {
 			if isNullIterationError(err) {
-				slog.Warn("mask selector matched nothing", "selector", selector)
+				reg.recordMatch(selector, 0)
 				continue
 			}
 			return nil, fmt.Errorf("failed to apply mask selector %q: %w", selector, err)
@@ -143,9 +171,7 @@ func applyMask(root any, selectors []string, reg *maskTokenRegistry) (any, error
 			return nil, fmt.Errorf("failed to apply mask selector %q: %w", selector, maskErr)
 		}
 		root = v
-		if matched == 0 {
-			slog.Warn("mask selector matched nothing", "selector", selector)
-		}
+		reg.recordMatch(selector, matched)
 	}
 	return root, nil
 }
@@ -177,7 +203,13 @@ func deepCopyJSONValue(x any) (any, error) {
 // render), where there is no second side to keep token-consistent. With no
 // selectors v is returned unchanged.
 func maskValue(v any, selectors []string) (any, error) {
-	return maskInput(v, "", selectors, newMaskTokenRegistry())
+	reg := newMaskTokenRegistry()
+	out, err := maskInput(v, "", selectors, reg)
+	if err != nil {
+		return nil, err
+	}
+	reg.warnUnmatched(selectors)
+	return out, nil
 }
 
 // maskInput returns x with the ignore query and then the mask selectors applied

--- a/mask_test.go
+++ b/mask_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"reflect"
 	"strings"
 	"testing"
@@ -224,6 +225,71 @@ func TestMaskInputNoSelectorsUntouched(t *testing.T) {
 	// same underlying value returned unchanged
 	if dumpJSON(t, got) != `{"a":1}` {
 		t.Errorf("maskInput with no selectors changed the value: %s", dumpJSON(t, got))
+	}
+}
+
+// captureWarnSelectors swaps the default slog logger for the duration of fn and
+// returns the "selector" attribute of every "mask selector matched nothing"
+// warning emitted.
+func captureWarnSelectors(t *testing.T, fn func()) []string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+	fn()
+	var got []string
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec struct {
+			Msg      string `json:"msg"`
+			Selector string `json:"selector"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("invalid log line %q: %v", line, err)
+		}
+		if rec.Msg == "mask selector matched nothing" {
+			got = append(got, rec.Selector)
+		}
+	}
+	return got
+}
+
+// TestMaskWarnUnmatchedOneSide verifies the both-sides accounting: a selector
+// that matches on only one diff side (e.g. a field empty/omitted on the other)
+// is not warned about, because masking did take effect somewhere.
+func TestMaskWarnUnmatchedOneSide(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	sel := []string{".Description"}
+	// remote has a non-empty Description, local omits it (empty -> omitted).
+	if _, err := applyMask(mustJSON(t, `{"Description":"hello"}`), sel, reg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := applyMask(mustJSON(t, `{"FunctionName":"x"}`), sel, reg); err != nil {
+		t.Fatal(err)
+	}
+	got := captureWarnSelectors(t, func() { reg.warnUnmatched(sel) })
+	if len(got) != 0 {
+		t.Errorf("did not expect a warning when the selector matched one side, got %v", got)
+	}
+}
+
+// TestMaskWarnUnmatchedNeitherSide verifies that a selector matching on neither
+// side (a likely typo, or a field empty/omitted on both sides) is warned about.
+func TestMaskWarnUnmatchedNeitherSide(t *testing.T) {
+	reg := newMaskTokenRegistry()
+	sel := []string{".Nope"}
+	if _, err := applyMask(mustJSON(t, `{"Description":"hello"}`), sel, reg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := applyMask(mustJSON(t, `{"FunctionName":"x"}`), sel, reg); err != nil {
+		t.Fatal(err)
+	}
+	got := captureWarnSelectors(t, func() { reg.warnUnmatched(sel) })
+	if len(got) != 1 || got[0] != ".Nope" {
+		t.Errorf("expected one warning for .Nope, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## What

- Preserve empty string values inside `Environment.Variables` in `diff` and `render` output. Other empty fields are still omitted.
- Warn about a `--mask` selector that matched nothing only when it matches **neither** side of the diff, instead of once per side.

## Why

`omitEmptyValues` stripped empty strings from the entire definition, so an intentionally-empty environment variable was hidden in `diff`/`render` even though `deploy` sends it to AWS as-is (an empty variable is distinct from an unset one for `os.LookupEnv` and similar). Top-level empty defaults (e.g. `Description`) stay omitted to avoid noisy output.

The mask "matched nothing" warning was emitted per side, so masking a field present on one side but empty/absent on the other warned even though masking did take effect. The match count is now accumulated in the shared token registry and warned once per selector only when it matched on neither side.