### PR TITLE
Fix spurious diff for functions using self-managed code storage

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -79,6 +79,18 @@ func (app *App) Diff(ctx context.Context, opt *DiffOption) error {
 	return nil
 }
 
+// normalizeCodeForDiff clears S3ObjectVersion on the remote function when the
+// local definition does not pin it, because lambroll resolves the version at
+// deploy time after uploading the zip.
+func normalizeCodeForDiff(local, remote *Function) {
+	if remote == nil || remote.Code == nil {
+		return
+	}
+	if local.Code == nil || local.Code.S3ObjectVersion == nil {
+		remote.Code.S3ObjectVersion = nil
+	}
+}
+
 func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption) (bool, error) {
 	if opt.SkipFunction {
 		return false, nil
@@ -120,6 +132,7 @@ func (app *App) diffFunction(ctx context.Context, fn *Function, opt *DiffOption)
 	}
 	remoteFunc := newFunctionFrom(remote, code, tags)
 	fillDefaultValues(remoteFunc)
+	normalizeCodeForDiff(fn, remoteFunc)
 
 	// AWS returns VPC subnet/security group IDs in an arbitrary order, so
 	// normalize the ordering on both sides to avoid a spurious diff.

--- a/export_test.go
+++ b/export_test.go
@@ -23,6 +23,7 @@ var (
 	RunExternalDiff            = runExternalDiff
 	RenderForExternalDiff      = renderForExternalDiff
 	NewUpdateFunctionCodeInput = newUpdateFunctionCodeInput
+	NormalizeCodeForDiff       = normalizeCodeForDiff
 )
 
 func (o *DiffOption) SetWriter(w io.Writer) {

--- a/function_test.go
+++ b/function_test.go
@@ -176,3 +176,96 @@ func TestNewFunctionWithDurableConfig(t *testing.T) {
 		t.Errorf("unexpected function got %s", diff)
 	}
 }
+
+func TestNewFunctionWithResolvedS3Object(t *testing.T) {
+	conf := &types.FunctionConfiguration{
+		FunctionName: aws.String("hello"),
+		MemorySize:   aws.Int32(128),
+		Runtime:      types.RuntimeNodejs18x,
+		Timeout:      aws.Int32(3),
+		Handler:      aws.String("index.handler"),
+		Role:         aws.String("arn:aws:iam::0123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
+	}
+	code := &types.FunctionCodeLocation{
+		RepositoryType: aws.String("S3"),
+		ResolvedS3Object: &types.ResolvedS3Object{
+			S3Bucket:        aws.String("my-bucket"),
+			S3Key:           aws.String("function.zip"),
+			S3ObjectVersion: aws.String("version123"),
+		},
+	}
+	fn := lambroll.NewFunctionFrom(conf, code, nil)
+
+	expected := lambroll.Function{
+		FunctionName: aws.String("hello"),
+		MemorySize:   aws.Int32(128),
+		Runtime:      types.RuntimeNodejs18x,
+		Timeout:      aws.Int32(3),
+		Handler:      aws.String("index.handler"),
+		Role:         aws.String("arn:aws:iam::0123456789012:role/YOUR_LAMBDA_ROLE_NAME"),
+		Code: &types.FunctionCode{
+			S3Bucket:            aws.String("my-bucket"),
+			S3Key:               aws.String("function.zip"),
+			S3ObjectVersion:     aws.String("version123"),
+			S3ObjectStorageMode: types.S3ObjectStorageModeReference,
+		},
+	}
+
+	fnJSON, _ := lambroll.MarshalJSON(fn)
+	expectedJSON, _ := lambroll.MarshalJSON(expected)
+	if diff := cmp.Diff(string(expectedJSON), string(fnJSON), ignore); diff != "" {
+		t.Errorf("unexpected function got %s", diff)
+	}
+}
+
+func TestNormalizeCodeForDiff(t *testing.T) {
+	newRemote := func() *lambroll.Function {
+		return &lambroll.Function{
+			Code: &types.FunctionCode{
+				S3Bucket:            aws.String("my-bucket"),
+				S3Key:               aws.String("function.zip"),
+				S3ObjectVersion:     aws.String("version123"),
+				S3ObjectStorageMode: types.S3ObjectStorageModeReference,
+			},
+		}
+	}
+
+	t.Run("local does not pin S3ObjectVersion", func(t *testing.T) {
+		local := &lambroll.Function{
+			Code: &types.FunctionCode{
+				S3Bucket:            aws.String("my-bucket"),
+				S3Key:               aws.String("function.zip"),
+				S3ObjectStorageMode: types.S3ObjectStorageModeReference,
+			},
+		}
+		remote := newRemote()
+		lambroll.NormalizeCodeForDiff(local, remote)
+		if remote.Code.S3ObjectVersion != nil {
+			t.Errorf("S3ObjectVersion must be cleared, got %s", *remote.Code.S3ObjectVersion)
+		}
+	})
+
+	t.Run("local pins S3ObjectVersion", func(t *testing.T) {
+		local := &lambroll.Function{
+			Code: &types.FunctionCode{
+				S3Bucket:        aws.String("my-bucket"),
+				S3Key:           aws.String("function.zip"),
+				S3ObjectVersion: aws.String("version456"),
+			},
+		}
+		remote := newRemote()
+		lambroll.NormalizeCodeForDiff(local, remote)
+		if aws.ToString(remote.Code.S3ObjectVersion) != "version123" {
+			t.Errorf("S3ObjectVersion must be kept, got %v", remote.Code.S3ObjectVersion)
+		}
+	})
+
+	t.Run("remote has no Code", func(t *testing.T) {
+		local := &lambroll.Function{}
+		remote := &lambroll.Function{}
+		lambroll.NormalizeCodeForDiff(local, remote)
+		if remote.Code != nil {
+			t.Errorf("remote.Code must be nil")
+		}
+	})
+}

--- a/init.go
+++ b/init.go
@@ -82,6 +82,12 @@ func (app *App) Init(ctx context.Context, opt *InitOption) error {
 		code = res.Code
 	}
 	fn := newFunctionFrom(c, code, tags)
+	if fn.Code != nil {
+		// The version resolved at GetFunction becomes stale immediately after
+		// the next upload. Writing it to the generated file would pin
+		// deployments with --skip-archive to the old object.
+		fn.Code.S3ObjectVersion = nil
+	}
 
 	if (opt.DownloadZip || opt.Unzip) && res != nil && res.Code != nil && aws.ToString(res.Code.RepositoryType) == "S3" {
 		slog.Info("downloading file", "file", FunctionZipFilename)

--- a/lambroll.go
+++ b/lambroll.go
@@ -358,6 +358,15 @@ func newFunctionFrom(c *types.FunctionConfiguration, code *types.FunctionCodeLoc
 		fn.Code = &types.FunctionCode{
 			ImageUri: code.ImageUri,
 		}
+	} else if code != nil && code.ResolvedS3Object != nil {
+		// ResolvedS3Object is returned only for functions using self-managed
+		// code storage (S3ObjectStorageMode=REFERENCE).
+		fn.Code = &types.FunctionCode{
+			S3Bucket:            code.ResolvedS3Object.S3Bucket,
+			S3Key:               code.ResolvedS3Object.S3Key,
+			S3ObjectVersion:     code.ResolvedS3Object.S3ObjectVersion,
+			S3ObjectStorageMode: types.S3ObjectStorageModeReference,
+		}
 	}
 
 	fn.Tags = tags


### PR DESCRIPTION
## What

- Restore the `Code` block from `GetFunction`'s `Code.ResolvedS3Object` in `newFunctionFrom` (as `S3Bucket` / `S3Key` / `S3ObjectVersion` / `S3ObjectStorageMode: "REFERENCE"`).
- `lambroll diff`: ignore the resolved `S3ObjectVersion` on the remote side unless the local definition explicitly pins it.
- `lambroll init`: omit `S3ObjectVersion` from the generated function file.

## Why

For functions deployed with self-managed code storage (#628), `lambroll diff` always showed the local `Code` block as an addition because the remote function reconstruction dropped it, even though the S3 location is part of the live function configuration and returned as `ResolvedS3Object`.

The resolved `S3ObjectVersion` is excluded from diff (unless pinned locally) and from init output because lambroll resolves it at deploy time after uploading the zip; writing a point-in-time version into the definition file would pin `--skip-archive` deployments to a stale object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)